### PR TITLE
Nuisance parameters to model PDF / scale uncertainties

### DIFF
--- a/madminer/__init__.py
+++ b/madminer/__init__.py
@@ -1,1 +1,14 @@
 from madminer.__version__ import __version__
+
+import logging
+logger = logging.getLogger(__name__)
+
+logger.info("")
+logger.info("------------------------------------------------------------")
+logger.info("|                                                          |")
+logger.info("|  MadMiner v{}|".format(__version__.ljust(46)))
+logger.info("|                                                          |")
+logger.info("|           Johann Brehmer, Kyle Cranmer, and Felix Kling  |")
+logger.info("|                                                          |")
+logger.info("------------------------------------------------------------")
+logger.info("")

--- a/madminer/__init__.py
+++ b/madminer/__init__.py
@@ -1,6 +1,7 @@
 from madminer.__version__ import __version__
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 logger.info("")

--- a/madminer/core.py
+++ b/madminer/core.py
@@ -886,8 +886,7 @@ class MadMiner:
                     export_run_card(
                         template_filename=run_card_file,
                         run_card_filename=mg_process_directory + "/" + new_run_card_file,
-                        run_systematics=self.run_systematics,
-                        systematics_arguments=self.systematics_arguments,
+                        systematics=self.systematics,
                     )
 
                 # Copy Pythia card

--- a/madminer/core.py
+++ b/madminer/core.py
@@ -38,7 +38,7 @@ class MadMiner:
     """
 
     def __init__(self, debug=False):
-        general_init(debug=debug)
+        self.logger = general_init(debug=debug)
 
         self.parameters = OrderedDict()
         self.benchmarks = OrderedDict()
@@ -122,7 +122,7 @@ class MadMiner:
         # After manually adding parameters, the morphing information is not accurate anymore
         self.morpher = None
 
-        logging.info(
+        self.logger.info(
             "Added parameter %s (LHA: %s %s, maximal power in squared ME: %s, range: %s)",
             parameter_name,
             lha_block,
@@ -133,7 +133,7 @@ class MadMiner:
 
         # Reset benchmarks
         if len(self.benchmarks) > 0:
-            logging.warning("Resetting benchmarks and morphing")
+            self.logger.warning("Resetting benchmarks and morphing")
 
         self.benchmarks = OrderedDict()
         self.default_benchmark = None
@@ -186,7 +186,7 @@ class MadMiner:
 
         # After manually adding parameters, the morphing information is not accurate anymore
         if len(self.benchmarks) > 0:
-            logging.warning("Resetting benchmarks and morphing")
+            self.logger.warning("Resetting benchmarks and morphing")
 
         self.benchmarks = OrderedDict()
         self.default_benchmark = None
@@ -241,7 +241,7 @@ class MadMiner:
         if len(self.benchmarks) == 1:
             self.default_benchmark = benchmark_name
 
-        logging.info("Added benchmark %s: %s)", benchmark_name, format_benchmark(parameter_values))
+        self.logger.info("Added benchmark %s: %s)", benchmark_name, format_benchmark(parameter_values))
 
     def set_benchmarks(self, benchmarks=None):
         """
@@ -276,7 +276,7 @@ class MadMiner:
 
         # After manually adding benchmarks, the morphing information is not accurate anymore
         if self.morpher is not None:
-            logging.warning("Reset morphing")
+            self.logger.warning("Reset morphing")
             self.morpher = None
             self.export_morphing = False
 
@@ -331,7 +331,7 @@ class MadMiner:
 
         """
 
-        logging.info("Optimizing basis for morphing")
+        self.logger.info("Optimizing basis for morphing")
 
         if isinstance(max_overall_power, int):
             max_overall_power = (max_overall_power,)
@@ -442,9 +442,9 @@ class MadMiner:
             _,
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=False)
 
-        logging.info("Found %s parameters:", len(self.parameters))
+        self.logger.info("Found %s parameters:", len(self.parameters))
         for key, values in six.iteritems(self.parameters):
-            logging.info(
+            self.logger.info(
                 "   %s (LHA: %s %s, maximal power in squared ME: %s, range: %s)",
                 key,
                 values[0],
@@ -453,9 +453,9 @@ class MadMiner:
                 values[3],
             )
 
-        logging.info("Found %s benchmarks:", len(self.benchmarks))
+        self.logger.info("Found %s benchmarks:", len(self.benchmarks))
         for key, values in six.iteritems(self.benchmarks):
-            logging.info("   %s: %s", key, format_benchmark(values))
+            self.logger.info("   %s: %s", key, format_benchmark(values))
 
             if self.default_benchmark is None:
                 self.default_benchmark = key
@@ -470,10 +470,10 @@ class MadMiner:
             self.morpher.set_basis(self.benchmarks, morphing_matrix=morphing_matrix)
             self.export_morphing = True
 
-            logging.info("Found morphing setup with %s components", len(morphing_components))
+            self.logger.info("Found morphing setup with %s components", len(morphing_components))
 
         else:
-            logging.info("Did not find morphing setup.")
+            self.logger.info("Did not find morphing setup.")
 
         # Systematics setup
         self.run_systematics = False
@@ -482,13 +482,13 @@ class MadMiner:
         self.systematics_arguments = ""
 
         if systematics_arguments is None or systematics_arguments == "":
-            logging.info("Did not find systematics setup.")
+            self.logger.info("Did not find systematics setup.")
         else:
             self.run_systematics = True
             self.run_scale_variation = "--muf" in systematics_arguments or "--mur" in systematics_arguments
             self.run_pdf_variation = "--pdf" in systematics_arguments
 
-            logging.info("Found systematics setup with options %s", systematics_arguments)
+            self.logger.info("Found systematics setup with options %s", systematics_arguments)
 
     def save(self, filename):
         """
@@ -520,7 +520,7 @@ class MadMiner:
         create_missing_folders([os.path.dirname(filename)])
 
         if self.morpher is not None:
-            logging.info("Saving setup (including morphing) to %s", filename)
+            self.logger.info("Saving setup (including morphing) to %s", filename)
 
             save_madminer_settings(
                 filename=filename,
@@ -532,7 +532,7 @@ class MadMiner:
                 overwrite_existing_files=True,
             )
         else:
-            logging.info("Saving setup (without morphing) to %s", filename)
+            self.logger.info("Saving setup (without morphing) to %s", filename)
 
             save_madminer_settings(
                 filename=filename,
@@ -582,9 +582,9 @@ class MadMiner:
         """
 
         if param_card_filename is None or reweight_card_filename is None:
-            logging.info("Creating param and reweight cards in %s", mg_process_directory)
+            self.logger.info("Creating param and reweight cards in %s", mg_process_directory)
         else:
-            logging.info("Creating param and reweight cards in %s, %s", param_card_filename, reweight_card_filename)
+            self.logger.info("Creating param and reweight cards in %s, %s", param_card_filename, reweight_card_filename)
 
         # Check status
         assert self.default_benchmark is not None
@@ -866,19 +866,19 @@ class MadMiner:
                 if run_card_file is not None:
                     new_run_card_file = "/madminer/cards/run_card_{}.dat".format(i)
 
-                logging.info("Run %s", i)
-                logging.info("  Sampling from benchmark: %s", sample_benchmark)
-                logging.info("  Original run card:       %s", run_card_file)
-                logging.info("  Original Pythia8 card:   %s", pythia8_card_file)
-                logging.info("  Copied run card:         %s", new_run_card_file)
-                logging.info("  Copied Pythia8 card:     %s", new_pythia8_card_file)
-                logging.info("  Param card:              %s", param_card_file)
-                logging.info("  Reweight card:           %s", reweight_card_file)
-                logging.info("  Log file:                %s", log_file_run)
+                self.logger.info("Run %s", i)
+                self.logger.info("  Sampling from benchmark: %s", sample_benchmark)
+                self.logger.info("  Original run card:       %s", run_card_file)
+                self.logger.info("  Original Pythia8 card:   %s", pythia8_card_file)
+                self.logger.info("  Copied run card:         %s", new_run_card_file)
+                self.logger.info("  Copied Pythia8 card:     %s", new_pythia8_card_file)
+                self.logger.info("  Param card:              %s", param_card_file)
+                self.logger.info("  Reweight card:           %s", reweight_card_file)
+                self.logger.info("  Log file:                %s", log_file_run)
 
                 # Check input
                 if run_card_file is None and self.run_systematics:
-                    logging.warning(
+                    self.logger.warning(
                         "Warning: No run card given, but systematics set up. The correct systematics"
                         " settings are not set automatically. Make sure to set them correctly!"
                     )
@@ -959,7 +959,7 @@ class MadMiner:
 
             make_file_executable(master_script_filename)
 
-            logging.info(
+            self.logger.info(
                 "To generate events, please run:\n\n %s [MG_directory] [MG_process_directory] [log_dir]\n\n",
                 master_script_filename,
             )

--- a/madminer/core.py
+++ b/madminer/core.py
@@ -50,13 +50,13 @@ class MadMiner:
         self.systematics_arguments = ""
 
     def add_parameter(
-            self,
-            lha_block,
-            lha_id,
-            parameter_name=None,
-            param_card_transform=None,
-            morphing_max_power=2,
-            parameter_range=(0.0, 1.0),
+        self,
+        lha_block,
+        lha_id,
+        parameter_name=None,
+        param_card_transform=None,
+        morphing_max_power=2,
+        parameter_range=(0.0, 1.0),
     ):
 
         """
@@ -280,7 +280,7 @@ class MadMiner:
             self.export_morphing = False
 
     def set_morphing(
-            self, max_overall_power=4, n_bases=1, include_existing_benchmarks=True, n_trials=100, n_test_thetas=100
+        self, max_overall_power=4, n_bases=1, include_existing_benchmarks=True, n_trials=100, n_test_thetas=100
     ):
         """
         Sets up the morphing environment.
@@ -542,12 +542,12 @@ class MadMiner:
             )
 
     def _export_cards(
-            self,
-            param_card_template_file,
-            mg_process_directory,
-            sample_benchmark=None,
-            param_card_filename=None,
-            reweight_card_filename=None,
+        self,
+        param_card_template_file,
+        mg_process_directory,
+        sample_benchmark=None,
+        param_card_filename=None,
+        reweight_card_filename=None,
     ):
 
         """
@@ -612,20 +612,20 @@ class MadMiner:
         )
 
     def run(
-            self,
-            mg_directory,
-            proc_card_file,
-            param_card_template_file,
-            run_card_file=None,
-            mg_process_directory=None,
-            pythia8_card_file=None,
-            sample_benchmark=None,
-            is_background=False,
-            only_prepare_script=False,
-            ufo_model_directory=None,
-            log_directory=None,
-            temp_directory=None,
-            initial_command=None,
+        self,
+        mg_directory,
+        proc_card_file,
+        param_card_template_file,
+        run_card_file=None,
+        mg_process_directory=None,
+        pythia8_card_file=None,
+        sample_benchmark=None,
+        is_background=False,
+        only_prepare_script=False,
+        ufo_model_directory=None,
+        log_directory=None,
+        temp_directory=None,
+        initial_command=None,
     ):
 
         """
@@ -725,20 +725,20 @@ class MadMiner:
         )
 
     def run_multiple(
-            self,
-            mg_directory,
-            proc_card_file,
-            param_card_template_file,
-            run_card_files,
-            mg_process_directory=None,
-            pythia8_card_file=None,
-            sample_benchmarks=None,
-            is_background=False,
-            only_prepare_script=False,
-            ufo_model_directory=None,
-            log_directory=None,
-            temp_directory=None,
-            initial_command=None,
+        self,
+        mg_directory,
+        proc_card_file,
+        param_card_template_file,
+        run_card_files,
+        mg_process_directory=None,
+        pythia8_card_file=None,
+        sample_benchmarks=None,
+        is_background=False,
+        only_prepare_script=False,
+        ufo_model_directory=None,
+        log_directory=None,
+        temp_directory=None,
+        initial_command=None,
     ):
 
         """
@@ -948,9 +948,9 @@ class MadMiner:
 
             commands = "\n".join(results)
             script = (
-                    "#!/bin/bash\n\n# Master script to generate events for MadMiner\n\n"
-                    + "# Usage: run.sh [MG_directory] [MG_process_directory] [log_directory]\n\n"
-                    + "{}\n\n{}"
+                "#!/bin/bash\n\n# Master script to generate events for MadMiner\n\n"
+                + "# Usage: run.sh [MG_directory] [MG_process_directory] [log_directory]\n\n"
+                + "{}\n\n{}"
             ).format(placeholder_definition, commands)
 
             with open(master_script_filename, "w") as file:

--- a/madminer/core.py
+++ b/madminer/core.py
@@ -51,13 +51,13 @@ class MadMiner:
         self.systematics_arguments = ""
 
     def add_parameter(
-        self,
-        lha_block,
-        lha_id,
-        parameter_name=None,
-        param_card_transform=None,
-        morphing_max_power=2,
-        parameter_range=(0.0, 1.0),
+            self,
+            lha_block,
+            lha_id,
+            parameter_name=None,
+            param_card_transform=None,
+            morphing_max_power=2,
+            parameter_range=(0.0, 1.0),
     ):
 
         """
@@ -281,7 +281,7 @@ class MadMiner:
             self.export_morphing = False
 
     def set_morphing(
-        self, max_overall_power=4, n_bases=1, include_existing_benchmarks=True, n_trials=100, n_test_thetas=100
+            self, max_overall_power=4, n_bases=1, include_existing_benchmarks=True, n_trials=100, n_test_thetas=100
     ):
         """
         Sets up the morphing environment.
@@ -430,7 +430,8 @@ class MadMiner:
         """
 
         # Load data
-        (self.parameters, self.benchmarks, _, morphing_components, morphing_matrix, _, _) = load_madminer_settings(
+        (self.parameters, self.benchmarks, _, morphing_components, morphing_matrix, _, _,
+         systematics_arguments) = load_madminer_settings(
             filename, include_nuisance_benchmarks=False
         )
 
@@ -466,6 +467,21 @@ class MadMiner:
 
         else:
             logging.info("Did not find morphing setup.")
+
+        # Systematics setup
+        self.run_systematics = False
+        self.run_scale_variation = False
+        self.run_pdf_variation = False
+        self.systematics_arguments = ""
+
+        if systematics_arguments is None or systematics_arguments == "":
+            logging.info("Did not find systematics setup.")
+        else:
+            self.run_systematics = True
+            self.run_scale_variation = ("--muf" in systematics_arguments or "--mur" in systematics_arguments)
+            self.run_pdf_variation = ("--pdf" in systematics_arguments)
+
+            logging.info("Found systematics setup with options %s", systematics_arguments)
 
     def save(self, filename):
         """
@@ -520,12 +536,12 @@ class MadMiner:
             )
 
     def _export_cards(
-        self,
-        param_card_template_file,
-        mg_process_directory,
-        sample_benchmark=None,
-        param_card_filename=None,
-        reweight_card_filename=None,
+            self,
+            param_card_template_file,
+            mg_process_directory,
+            sample_benchmark=None,
+            param_card_filename=None,
+            reweight_card_filename=None,
     ):
 
         """
@@ -590,20 +606,20 @@ class MadMiner:
         )
 
     def run(
-        self,
-        mg_directory,
-        proc_card_file,
-        param_card_template_file,
-        run_card_file=None,
-        mg_process_directory=None,
-        pythia8_card_file=None,
-        sample_benchmark=None,
-        is_background=False,
-        only_prepare_script=False,
-        ufo_model_directory=None,
-        log_directory=None,
-        temp_directory=None,
-        initial_command=None,
+            self,
+            mg_directory,
+            proc_card_file,
+            param_card_template_file,
+            run_card_file=None,
+            mg_process_directory=None,
+            pythia8_card_file=None,
+            sample_benchmark=None,
+            is_background=False,
+            only_prepare_script=False,
+            ufo_model_directory=None,
+            log_directory=None,
+            temp_directory=None,
+            initial_command=None,
     ):
 
         """
@@ -703,20 +719,20 @@ class MadMiner:
         )
 
     def run_multiple(
-        self,
-        mg_directory,
-        proc_card_file,
-        param_card_template_file,
-        run_card_files,
-        mg_process_directory=None,
-        pythia8_card_file=None,
-        sample_benchmarks=None,
-        is_background=False,
-        only_prepare_script=False,
-        ufo_model_directory=None,
-        log_directory=None,
-        temp_directory=None,
-        initial_command=None,
+            self,
+            mg_directory,
+            proc_card_file,
+            param_card_template_file,
+            run_card_files,
+            mg_process_directory=None,
+            pythia8_card_file=None,
+            sample_benchmarks=None,
+            is_background=False,
+            only_prepare_script=False,
+            ufo_model_directory=None,
+            log_directory=None,
+            temp_directory=None,
+            initial_command=None,
     ):
 
         """
@@ -926,9 +942,9 @@ class MadMiner:
 
             commands = "\n".join(results)
             script = (
-                "#!/bin/bash\n\n# Master script to generate events for MadMiner\n\n"
-                + "# Usage: run.sh [MG_directory] [MG_process_directory] [log_directory]\n\n"
-                + "{}\n\n{}"
+                    "#!/bin/bash\n\n# Master script to generate events for MadMiner\n\n"
+                    + "# Usage: run.sh [MG_directory] [MG_process_directory] [log_directory]\n\n"
+                    + "{}\n\n{}"
             ).format(placeholder_definition, commands)
 
             with open(master_script_filename, "w") as file:

--- a/madminer/core.py
+++ b/madminer/core.py
@@ -51,13 +51,13 @@ class MadMiner:
         self.systematics_arguments = ""
 
     def add_parameter(
-            self,
-            lha_block,
-            lha_id,
-            parameter_name=None,
-            param_card_transform=None,
-            morphing_max_power=2,
-            parameter_range=(0.0, 1.0),
+        self,
+        lha_block,
+        lha_id,
+        parameter_name=None,
+        param_card_transform=None,
+        morphing_max_power=2,
+        parameter_range=(0.0, 1.0),
     ):
 
         """
@@ -281,7 +281,7 @@ class MadMiner:
             self.export_morphing = False
 
     def set_morphing(
-            self, max_overall_power=4, n_bases=1, include_existing_benchmarks=True, n_trials=100, n_test_thetas=100
+        self, max_overall_power=4, n_bases=1, include_existing_benchmarks=True, n_trials=100, n_test_thetas=100
     ):
         """
         Sets up the morphing environment.
@@ -430,10 +430,16 @@ class MadMiner:
         """
 
         # Load data
-        (self.parameters, self.benchmarks, _, morphing_components, morphing_matrix, _, _,
-         systematics_arguments) = load_madminer_settings(
-            filename, include_nuisance_benchmarks=False
-        )
+        (
+            self.parameters,
+            self.benchmarks,
+            _,
+            morphing_components,
+            morphing_matrix,
+            _,
+            _,
+            systematics_arguments,
+        ) = load_madminer_settings(filename, include_nuisance_benchmarks=False)
 
         logging.info("Found %s parameters:", len(self.parameters))
         for key, values in six.iteritems(self.parameters):
@@ -478,8 +484,8 @@ class MadMiner:
             logging.info("Did not find systematics setup.")
         else:
             self.run_systematics = True
-            self.run_scale_variation = ("--muf" in systematics_arguments or "--mur" in systematics_arguments)
-            self.run_pdf_variation = ("--pdf" in systematics_arguments)
+            self.run_scale_variation = "--muf" in systematics_arguments or "--mur" in systematics_arguments
+            self.run_pdf_variation = "--pdf" in systematics_arguments
 
             logging.info("Found systematics setup with options %s", systematics_arguments)
 
@@ -536,12 +542,12 @@ class MadMiner:
             )
 
     def _export_cards(
-            self,
-            param_card_template_file,
-            mg_process_directory,
-            sample_benchmark=None,
-            param_card_filename=None,
-            reweight_card_filename=None,
+        self,
+        param_card_template_file,
+        mg_process_directory,
+        sample_benchmark=None,
+        param_card_filename=None,
+        reweight_card_filename=None,
     ):
 
         """
@@ -606,20 +612,20 @@ class MadMiner:
         )
 
     def run(
-            self,
-            mg_directory,
-            proc_card_file,
-            param_card_template_file,
-            run_card_file=None,
-            mg_process_directory=None,
-            pythia8_card_file=None,
-            sample_benchmark=None,
-            is_background=False,
-            only_prepare_script=False,
-            ufo_model_directory=None,
-            log_directory=None,
-            temp_directory=None,
-            initial_command=None,
+        self,
+        mg_directory,
+        proc_card_file,
+        param_card_template_file,
+        run_card_file=None,
+        mg_process_directory=None,
+        pythia8_card_file=None,
+        sample_benchmark=None,
+        is_background=False,
+        only_prepare_script=False,
+        ufo_model_directory=None,
+        log_directory=None,
+        temp_directory=None,
+        initial_command=None,
     ):
 
         """
@@ -719,20 +725,20 @@ class MadMiner:
         )
 
     def run_multiple(
-            self,
-            mg_directory,
-            proc_card_file,
-            param_card_template_file,
-            run_card_files,
-            mg_process_directory=None,
-            pythia8_card_file=None,
-            sample_benchmarks=None,
-            is_background=False,
-            only_prepare_script=False,
-            ufo_model_directory=None,
-            log_directory=None,
-            temp_directory=None,
-            initial_command=None,
+        self,
+        mg_directory,
+        proc_card_file,
+        param_card_template_file,
+        run_card_files,
+        mg_process_directory=None,
+        pythia8_card_file=None,
+        sample_benchmarks=None,
+        is_background=False,
+        only_prepare_script=False,
+        ufo_model_directory=None,
+        log_directory=None,
+        temp_directory=None,
+        initial_command=None,
     ):
 
         """
@@ -942,9 +948,9 @@ class MadMiner:
 
             commands = "\n".join(results)
             script = (
-                    "#!/bin/bash\n\n# Master script to generate events for MadMiner\n\n"
-                    + "# Usage: run.sh [MG_directory] [MG_process_directory] [log_directory]\n\n"
-                    + "{}\n\n{}"
+                "#!/bin/bash\n\n# Master script to generate events for MadMiner\n\n"
+                + "# Usage: run.sh [MG_directory] [MG_process_directory] [log_directory]\n\n"
+                + "{}\n\n{}"
             ).format(placeholder_definition, commands)
 
             with open(master_script_filename, "w") as file:

--- a/madminer/core.py
+++ b/madminer/core.py
@@ -435,6 +435,7 @@ class MadMiner:
             _,
             self.systematics,
             _,
+            _,
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=False)
 
         logger.info("Found %s parameters:", len(self.parameters))

--- a/madminer/core.py
+++ b/madminer/core.py
@@ -439,6 +439,7 @@ class MadMiner:
             _,
             _,
             systematics_arguments,
+            _,
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=False)
 
         logging.info("Found %s parameters:", len(self.parameters))

--- a/madminer/delphes.py
+++ b/madminer/delphes.py
@@ -4,6 +4,7 @@ import six
 from collections import OrderedDict
 import numpy as np
 import logging
+import os
 
 from madminer.utils.interfaces.madminer_hdf5 import (
     save_events_to_madminer_file,
@@ -199,7 +200,7 @@ class DelphesProcessor:
         for i, (delphes_filename, hepmc_filename) in enumerate(
             zip(self.delphes_sample_filenames, self.hepmc_sample_filenames)
         ):
-            if delphes_filename is not None:
+            if delphes_filename is not None and os.path.isfile(delphes_filename):
                 logger.debug("Delphes already run for event sample %s", hepmc_filename)
                 continue
 

--- a/madminer/delphes.py
+++ b/madminer/delphes.py
@@ -697,7 +697,6 @@ class DelphesProcessor:
                 assert key in this_observations, "Observable {} not found in Delphes sample!".format(key)
                 self.observations[key] = np.hstack([self.observations[key], this_observations[key]])
 
-
     def save(self, filename_out):
         """
         Saves the observable definitions, observable values, and event weights in a MadMiner file. The parameter,
@@ -734,9 +733,4 @@ class DelphesProcessor:
         )
 
         # Save events
-        save_events_to_madminer_file(
-            filename_out,
-            self.observables,
-            self.observations,
-            self.weights,
-        )
+        save_events_to_madminer_file(filename_out, self.observables, self.observations, self.weights)

--- a/madminer/delphes.py
+++ b/madminer/delphes.py
@@ -94,7 +94,7 @@ class DelphesProcessor:
 
         # Information from .h5 file
         self.filename = filename
-        (parameters, benchmarks, _, _, _, _, _, self.systematics, _) = load_madminer_settings(
+        (parameters, benchmarks, _, _, _, _, _, self.systematics, _, _) = load_madminer_settings(
             filename, include_nuisance_benchmarks=False
         )
         self.benchmark_names_phys = list(benchmarks.keys())
@@ -569,7 +569,7 @@ class DelphesProcessor:
 
             # Compare to existing data
             if self.nuisance_parameters is None:
-                self.nuisance_parameters == nuisance_parameters
+                self.nuisance_parameters = nuisance_parameters
             else:
                 if dict(self.nuisance_parameters) != dict(nuisance_parameters):
                     raise RuntimeError(

--- a/madminer/delphes.py
+++ b/madminer/delphes.py
@@ -7,7 +7,7 @@ import logging
 
 from madminer.utils.interfaces.madminer_hdf5 import (
     save_events_to_madminer_file,
-    load_benchmarks_from_madminer_file,
+    load_madminer_settings,
     save_nuisance_benchmarks_to_madminer_file,
 )
 from madminer.utils.interfaces.delphes import run_delphes
@@ -89,8 +89,11 @@ class DelphesProcessor:
 
         # Information from .h5 file
         self.filename = filename
-        self.benchmark_names = load_benchmarks_from_madminer_file(self.filename)
-        self.n_benchmarks = len(self.benchmark_names)
+        (parameters, benchmarks, _, _, _, _, _, self.systematics, _) = load_madminer_settings(
+            filename, include_nuisance_benchmarks=False
+        )
+        self.benchmark_names = list(benchmarks.keys())
+        self.n_benchmarks = len(benchmarks)
 
     def add_sample(
         self,

--- a/madminer/delphes.py
+++ b/madminer/delphes.py
@@ -682,7 +682,9 @@ class DelphesProcessor:
         weight_names = list(self.weights.keys())
         logging.debug("Weight names: %s", weight_names)
 
-        save_nuisance_benchmarks_to_madminer_file(filename_out, weight_names, reference_benchmark=self.reference_benchmark, copy_from=self.filename)
+        save_nuisance_benchmarks_to_madminer_file(
+            filename_out, weight_names, reference_benchmark=self.reference_benchmark, copy_from=self.filename
+        )
 
         # Save events
         save_events_to_madminer_file(

--- a/madminer/delphes.py
+++ b/madminer/delphes.py
@@ -83,6 +83,7 @@ class DelphesProcessor:
         self.acceptance_eta_max_j = None
 
         # Initialize samples
+        self.reference_benchmark = None
         self.observations = None
         self.weights = None
         self.sampled_from_benchmark = None
@@ -512,6 +513,7 @@ class DelphesProcessor:
         # Input
         if reference_benchmark is None:
             reference_benchmark = self.benchmark_names[0]
+        self.reference_benchmark = reference_benchmark
 
         # Reset observations
         self.observations = None
@@ -680,7 +682,7 @@ class DelphesProcessor:
         weight_names = list(self.weights.keys())
         logging.debug("Weight names: %s", weight_names)
 
-        save_nuisance_benchmarks_to_madminer_file(filename_out, weight_names, copy_from=self.filename)
+        save_nuisance_benchmarks_to_madminer_file(filename_out, weight_names, reference_benchmark=self.reference_benchmark, copy_from=self.filename)
 
         # Save events
         save_events_to_madminer_file(

--- a/madminer/delphes.py
+++ b/madminer/delphes.py
@@ -87,7 +87,6 @@ class DelphesProcessor:
         self.reference_benchmark = None
         self.observations = None
         self.weights = None
-        self.sampled_from_benchmark = None
 
         # Initialize nuisance parameters
         self.nuisance_parameters = None
@@ -538,7 +537,6 @@ class DelphesProcessor:
         # Reset observations
         self.observations = None
         self.weights = None
-        self.sampled_from_benchmark = None
         self.nuisance_parameters = None
 
         for (
@@ -674,7 +672,6 @@ class DelphesProcessor:
             if self.observations is None and self.weights is None:
                 self.observations = this_observations
                 self.weights = this_weights
-                self.sampled_from_benchmark = [sampling_benchmark for _ in range(n_events)]
                 continue
 
             # Following results: check consistency with previous results
@@ -700,7 +697,6 @@ class DelphesProcessor:
                 assert key in this_observations, "Observable {} not found in Delphes sample!".format(key)
                 self.observations[key] = np.hstack([self.observations[key], this_observations[key]])
 
-            self.sampled_from_benchmark += [sampling_benchmark for _ in range(n_events)]
 
     def save(self, filename_out):
         """
@@ -743,5 +739,4 @@ class DelphesProcessor:
             self.observables,
             self.observations,
             self.weights,
-            sampled_from_benchmark=self.sampled_from_benchmark,
         )

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -44,11 +44,11 @@ def project_information(fisher_information, remaining_components):
 
 
 def profile_information(
-    fisher_information,
-    remaining_components,
-    covariance=None,
-    error_propagation_n_ensemble=1000,
-    error_propagation_factor=1.0e-3,
+        fisher_information,
+        remaining_components,
+        covariance=None,
+        error_propagation_n_ensemble=1000,
+        error_propagation_factor=1.0e-3,
 ):
     """
     Calculates the profiled Fisher information matrix as defined in Appendix A.4 of arXiv:1612.05261.
@@ -242,7 +242,7 @@ class FisherInformation:
             raise RuntimeError("Did not find morphing setup.")
 
     def calculate_fisher_information_full_truth(
-        self, theta, luminosity=300000.0, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
+            self, theta, luminosity=300000.0, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
     ):
         """
         Calculates the full Fisher information at parton / truth level. This is the information in an idealized
@@ -295,7 +295,7 @@ class FisherInformation:
         covariance = np.zeros((n_all_parameters, n_all_parameters, n_all_parameters, n_all_parameters))
 
         for observations, weights in madminer_event_loader(
-            self.madminer_filename, include_nuisance_parameters=include_nuisance_parameters
+                self.madminer_filename, include_nuisance_parameters=include_nuisance_parameters
         ):
             # Cuts
             cut_filter = [self._pass_cuts(obs_event, cuts) for obs_event in observations]
@@ -323,17 +323,17 @@ class FisherInformation:
         return fisher_info, covariance
 
     def calculate_fisher_information_full_detector(
-        self,
-        theta,
-        model_file,
-        unweighted_x_sample_file=None,
-        luminosity=300000.0,
-        include_xsec_info=True,
-        mode="information",
-        uncertainty="ensemble",
-        ensemble_vote_expectation_weight=None,
-        batch_size=100000,
-        test_split=0.5,
+            self,
+            theta,
+            model_file,
+            unweighted_x_sample_file=None,
+            luminosity=300000.0,
+            include_xsec_info=True,
+            mode="information",
+            uncertainty="ensemble",
+            ensemble_vote_expectation_weight=None,
+            batch_size=100000,
+            test_split=0.5,
     ):
         """
         Calculates the full Fisher information in realistic detector-level observations, estimated with neural networks.
@@ -478,12 +478,12 @@ class FisherInformation:
             n_batches = int(np.ceil((self.n_samples - start_event) / batch_size))
 
             for i_batch, (observations, weights_benchmarks) in enumerate(
-                madminer_event_loader(
-                    self.madminer_filename,
-                    batch_size=batch_size,
-                    start=start_event,
-                    include_nuisance_parameters=include_nuisance_parameters,
-                )
+                    madminer_event_loader(
+                        self.madminer_filename,
+                        batch_size=batch_size,
+                        start=start_event,
+                        include_nuisance_parameters=include_nuisance_parameters,
+                    )
             ):
                 logging.info("Evaluating kinematic Fisher information on batch %s / %s", i_batch + 1, n_batches)
 
@@ -554,7 +554,7 @@ class FisherInformation:
         return fisher_info_rate + fisher_info_kin, rate_covariance
 
     def calculate_fisher_information_rate(
-        self, theta, luminosity, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
+            self, theta, luminosity, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
     ):
         """
         Calculates the Fisher information in a measurement of the total cross section (without any kinematic
@@ -616,15 +616,15 @@ class FisherInformation:
         return fisher_info, covariance
 
     def calculate_fisher_information_hist1d(
-        self,
-        theta,
-        luminosity,
-        observable,
-        nbins,
-        histrange=None,
-        cuts=None,
-        efficiency_functions=None,
-        n_events_dynamic_binning=100000,
+            self,
+            theta,
+            luminosity,
+            observable,
+            nbins,
+            histrange=None,
+            cuts=None,
+            efficiency_functions=None,
+            n_events_dynamic_binning=100000,
     ):
         """
         Calculates the Fisher information in the one-dimensional histogram of an (parton-level or detector-level,
@@ -758,17 +758,17 @@ class FisherInformation:
         return fisher_info, covariance
 
     def calculate_fisher_information_hist2d(
-        self,
-        theta,
-        luminosity,
-        observable1,
-        nbins1,
-        histrange1,
-        observable2,
-        nbins2,
-        histrange2,
-        cuts=None,
-        efficiency_functions=None,
+            self,
+            theta,
+            luminosity,
+            observable1,
+            nbins1,
+            histrange1,
+            observable2,
+            nbins2,
+            histrange2,
+            cuts=None,
+            efficiency_functions=None,
     ):
 
         """
@@ -875,7 +875,7 @@ class FisherInformation:
         return fisher_info
 
     def histogram_of_fisher_information(
-        self, theta, luminosity, observable, nbins, histrange, cuts=None, efficiency_functions=None
+            self, theta, luminosity, observable, nbins, histrange, cuts=None, efficiency_functions=None
     ):
         """
         Calculates the full and rate-only Fisher information in slices of one observable.
@@ -1040,14 +1040,14 @@ class FisherInformation:
         return x, weights_thetas
 
     def _calculate_fisher_information(
-        self,
-        theta,
-        weights_benchmarks,
-        luminosity=300000.0,
-        include_nuisance_parameters=True,
-        sum_events=False,
-        calculate_uncertainty=False,
-        weights_benchmark_uncertainties=None,
+            self,
+            theta,
+            weights_benchmarks,
+            luminosity=300000.0,
+            include_nuisance_parameters=True,
+            sum_events=False,
+            calculate_uncertainty=False,
+            weights_benchmark_uncertainties=None,
     ):
         """
         Low-level function that calculates a list of full Fisher information matrices for a given parameter point and
@@ -1110,9 +1110,14 @@ class FisherInformation:
 
         # Nuisance parameter Fisher info
         if include_nuisance_parameters:
-            i_ref_benchmark = list(self.benchmarks.keys()).index(self.reference_benchmark)
+            if self.reference_benchmark is None:
+                logging.warning("Reference benchmark unknown, using first benchmark")
+                i_ref_benchmark = 0
+            else:
+                i_ref_benchmark = list(self.benchmarks.keys()).index(self.reference_benchmark)
             nuisance_weight_ratio = (
-                weights_benchmarks.T[self.benchmark_is_nuisance, :] / weights_benchmarks[np.newaxis, :, i_ref_benchmark]
+                    weights_benchmarks.T[self.benchmark_is_nuisance, :] / weights_benchmarks[np.newaxis, :,
+                                                                          i_ref_benchmark]
             )
             # Shape (n_nuisance_parameters, n_events)
 
@@ -1125,11 +1130,11 @@ class FisherInformation:
             fisher_info_mix = luminosity * np.einsum("in,jn->nij", dsigma, np.log(nuisance_weight_ratio))
 
             n_all_parameters = self.n_parameters + self.n_nuisance_parameters
-            fisher_info = np.zeros((n_all_parameters, n_all_parameters))
-            fisher_info[: self.n_parameters, : self.n_parameters] = fisher_info_phys
-            fisher_info[: self.n_parameters, self.n_parameters :] = fisher_info_mix
-            fisher_info[self.n_parameters :, : self.n_parameters] = fisher_info_mix.T
-            fisher_info[self.n_parameters :, self.n_parameters :] = fisher_info_nuisance
+            fisher_info = np.zeros((fisher_info_phys.shape[0], n_all_parameters, n_all_parameters))
+            fisher_info[:, :self.n_parameters, :self.n_parameters] = fisher_info_phys
+            fisher_info[:, :self.n_parameters, self.n_parameters:] = fisher_info_mix
+            fisher_info[:, self.n_parameters:, :self.n_parameters] = fisher_info_mix.T
+            fisher_info[:, self.n_parameters:, self.n_parameters:] = fisher_info_nuisance
 
         else:
             n_all_parameters = self.n_parameters
@@ -1156,7 +1161,7 @@ class FisherInformation:
 
                 else:  # Off-diagonal, same event
                     covariance_inputs[i, b1, b2] = (
-                        weights_benchmark_uncertainties[i, b1] * weights_benchmark_uncertainties[i, b2]
+                            weights_benchmark_uncertainties[i, b1] * weights_benchmark_uncertainties[i, b2]
                     )
 
             # Jacobian
@@ -1295,14 +1300,14 @@ class FisherInformation:
         return float(eval(observable_definition, variables))
 
     def _calculate_xsec(
-        self,
-        theta=None,
-        cuts=None,
-        efficiency_functions=None,
-        return_benchmark_xsecs=False,
-        return_error=False,
-        include_nuisance_parameters=True,
-        start_event=0,
+            self,
+            theta=None,
+            cuts=None,
+            efficiency_functions=None,
+            return_benchmark_xsecs=False,
+            return_error=False,
+            include_nuisance_parameters=True,
+            start_event=0,
     ):
         """
         Calculates the total cross section for a parameter point.
@@ -1358,7 +1363,7 @@ class FisherInformation:
         xsecs_uncertainty_benchmarks = None
 
         for observations, weights in madminer_event_loader(
-            self.madminer_filename, start=start_event, include_nuisance_parameters=include_nuisance_parameters
+                self.madminer_filename, start=start_event, include_nuisance_parameters=include_nuisance_parameters
         ):
             # Cuts
             cut_filter = [self._pass_cuts(obs_event, cuts) for obs_event in observations]

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -43,7 +43,13 @@ def project_information(fisher_information, remaining_components):
     return fisher_information_new
 
 
-def profile_information(fisher_information, remaining_components, covariance=None, error_propagation_n_ensemble=1000, error_propagation_factor=1.e-3):
+def profile_information(
+    fisher_information,
+    remaining_components,
+    covariance=None,
+    error_propagation_n_ensemble=1000,
+    error_propagation_factor=1.0e-3,
+):
     """
     Calculates the profiled Fisher information matrix as defined in Appendix A.4 of arXiv:1612.05261.
 
@@ -115,8 +121,8 @@ def profile_information(fisher_information, remaining_components, covariance=Non
         # Draw toys
         information_toys = np.random.multivariate_normal(
             mean=fisher_information.reshape((-1,)),
-            cov=error_propagation_factor * covariance.reshape((n_components**2, n_components**2)),
-            size=error_propagation_n_ensemble
+            cov=error_propagation_factor * covariance.reshape((n_components ** 2, n_components ** 2)),
+            size=error_propagation_n_ensemble,
         )
         information_toys.reshape((-1, n_components, n_components))
 
@@ -124,8 +130,10 @@ def profile_information(fisher_information, remaining_components, covariance=Non
         profiled_information_toys = np.array([_profile(info) for info in information_toys])
 
         # Calculate ensemble covariance
-        toy_covariance = np.cov(profiled_information_toys.reshape((-1, n_remaining_components**2)).T)
-        toy_covariance = toy_covariance.reshape((n_remaining_components, n_remaining_components, n_remaining_components, n_remaining_components))
+        toy_covariance = np.cov(profiled_information_toys.reshape((-1, n_remaining_components ** 2)).T)
+        toy_covariance = toy_covariance.reshape(
+            (n_remaining_components, n_remaining_components, n_remaining_components, n_remaining_components)
+        )
         profiled_information_covariance = toy_covariance / error_propagation_factor
 
         # Cross-check: toy mean

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -44,11 +44,11 @@ def project_information(fisher_information, remaining_components):
 
 
 def profile_information(
-        fisher_information,
-        remaining_components,
-        covariance=None,
-        error_propagation_n_ensemble=1000,
-        error_propagation_factor=1.0e-3,
+    fisher_information,
+    remaining_components,
+    covariance=None,
+    error_propagation_n_ensemble=1000,
+    error_propagation_factor=1.0e-3,
 ):
     """
     Calculates the profiled Fisher information matrix as defined in Appendix A.4 of arXiv:1612.05261.
@@ -242,7 +242,7 @@ class FisherInformation:
             raise RuntimeError("Did not find morphing setup.")
 
     def calculate_fisher_information_full_truth(
-            self, theta, luminosity=300000.0, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
+        self, theta, luminosity=300000.0, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
     ):
         """
         Calculates the full Fisher information at parton / truth level. This is the information in an idealized
@@ -295,7 +295,7 @@ class FisherInformation:
         covariance = np.zeros((n_all_parameters, n_all_parameters, n_all_parameters, n_all_parameters))
 
         for observations, weights in madminer_event_loader(
-                self.madminer_filename, include_nuisance_parameters=include_nuisance_parameters
+            self.madminer_filename, include_nuisance_parameters=include_nuisance_parameters
         ):
             # Cuts
             cut_filter = [self._pass_cuts(obs_event, cuts) for obs_event in observations]
@@ -323,17 +323,17 @@ class FisherInformation:
         return fisher_info, covariance
 
     def calculate_fisher_information_full_detector(
-            self,
-            theta,
-            model_file,
-            unweighted_x_sample_file=None,
-            luminosity=300000.0,
-            include_xsec_info=True,
-            mode="information",
-            uncertainty="ensemble",
-            ensemble_vote_expectation_weight=None,
-            batch_size=100000,
-            test_split=0.5,
+        self,
+        theta,
+        model_file,
+        unweighted_x_sample_file=None,
+        luminosity=300000.0,
+        include_xsec_info=True,
+        mode="information",
+        uncertainty="ensemble",
+        ensemble_vote_expectation_weight=None,
+        batch_size=100000,
+        test_split=0.5,
     ):
         """
         Calculates the full Fisher information in realistic detector-level observations, estimated with neural networks.
@@ -478,12 +478,12 @@ class FisherInformation:
             n_batches = int(np.ceil((self.n_samples - start_event) / batch_size))
 
             for i_batch, (observations, weights_benchmarks) in enumerate(
-                    madminer_event_loader(
-                        self.madminer_filename,
-                        batch_size=batch_size,
-                        start=start_event,
-                        include_nuisance_parameters=include_nuisance_parameters,
-                    )
+                madminer_event_loader(
+                    self.madminer_filename,
+                    batch_size=batch_size,
+                    start=start_event,
+                    include_nuisance_parameters=include_nuisance_parameters,
+                )
             ):
                 logging.info("Evaluating kinematic Fisher information on batch %s / %s", i_batch + 1, n_batches)
 
@@ -554,7 +554,7 @@ class FisherInformation:
         return fisher_info_rate + fisher_info_kin, rate_covariance
 
     def calculate_fisher_information_rate(
-            self, theta, luminosity, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
+        self, theta, luminosity, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
     ):
         """
         Calculates the Fisher information in a measurement of the total cross section (without any kinematic
@@ -616,15 +616,15 @@ class FisherInformation:
         return fisher_info, covariance
 
     def calculate_fisher_information_hist1d(
-            self,
-            theta,
-            luminosity,
-            observable,
-            nbins,
-            histrange=None,
-            cuts=None,
-            efficiency_functions=None,
-            n_events_dynamic_binning=100000,
+        self,
+        theta,
+        luminosity,
+        observable,
+        nbins,
+        histrange=None,
+        cuts=None,
+        efficiency_functions=None,
+        n_events_dynamic_binning=100000,
     ):
         """
         Calculates the Fisher information in the one-dimensional histogram of an (parton-level or detector-level,
@@ -758,17 +758,17 @@ class FisherInformation:
         return fisher_info, covariance
 
     def calculate_fisher_information_hist2d(
-            self,
-            theta,
-            luminosity,
-            observable1,
-            nbins1,
-            histrange1,
-            observable2,
-            nbins2,
-            histrange2,
-            cuts=None,
-            efficiency_functions=None,
+        self,
+        theta,
+        luminosity,
+        observable1,
+        nbins1,
+        histrange1,
+        observable2,
+        nbins2,
+        histrange2,
+        cuts=None,
+        efficiency_functions=None,
     ):
 
         """
@@ -875,7 +875,7 @@ class FisherInformation:
         return fisher_info
 
     def histogram_of_fisher_information(
-            self, theta, luminosity, observable, nbins, histrange, cuts=None, efficiency_functions=None
+        self, theta, luminosity, observable, nbins, histrange, cuts=None, efficiency_functions=None
     ):
         """
         Calculates the full and rate-only Fisher information in slices of one observable.
@@ -1040,14 +1040,14 @@ class FisherInformation:
         return x, weights_thetas
 
     def _calculate_fisher_information(
-            self,
-            theta,
-            weights_benchmarks,
-            luminosity=300000.0,
-            include_nuisance_parameters=True,
-            sum_events=False,
-            calculate_uncertainty=False,
-            weights_benchmark_uncertainties=None,
+        self,
+        theta,
+        weights_benchmarks,
+        luminosity=300000.0,
+        include_nuisance_parameters=True,
+        sum_events=False,
+        calculate_uncertainty=False,
+        weights_benchmark_uncertainties=None,
     ):
         """
         Low-level function that calculates a list of full Fisher information matrices for a given parameter point and
@@ -1090,7 +1090,8 @@ class FisherInformation:
         fisher_information_uncertainty : ndarray
             Only returned if calculate_uncertainty is True. Covariance matrix of the Fisher information. Note that this
             does not take into account any uncertainty on the nuisance parameter part of the Fisher information, and
-            correlations between events are neglected.
+            correlations between events are neglected. Note that independent of sum_events, the covariance matrix is
+            always summed over the events.
 
         """
 
@@ -1116,8 +1117,7 @@ class FisherInformation:
             else:
                 i_ref_benchmark = list(self.benchmarks.keys()).index(self.reference_benchmark)
             nuisance_weight_ratio = (
-                    weights_benchmarks.T[self.benchmark_is_nuisance, :] / weights_benchmarks[np.newaxis, :,
-                                                                          i_ref_benchmark]
+                weights_benchmarks.T[self.benchmark_is_nuisance, :] / weights_benchmarks[np.newaxis, :, i_ref_benchmark]
             )
             # Shape (n_nuisance_parameters, n_events)
 
@@ -1131,10 +1131,10 @@ class FisherInformation:
 
             n_all_parameters = self.n_parameters + self.n_nuisance_parameters
             fisher_info = np.zeros((fisher_info_phys.shape[0], n_all_parameters, n_all_parameters))
-            fisher_info[:, :self.n_parameters, :self.n_parameters] = fisher_info_phys
-            fisher_info[:, :self.n_parameters, self.n_parameters:] = fisher_info_mix
-            fisher_info[:, self.n_parameters:, :self.n_parameters] = fisher_info_mix.T
-            fisher_info[:, self.n_parameters:, self.n_parameters:] = fisher_info_nuisance
+            fisher_info[:, : self.n_parameters, : self.n_parameters] = fisher_info_phys
+            fisher_info[:, : self.n_parameters, self.n_parameters :] = fisher_info_mix
+            fisher_info[:, self.n_parameters :, : self.n_parameters] = fisher_info_mix.T
+            fisher_info[:, self.n_parameters :, self.n_parameters :] = fisher_info_nuisance
 
         else:
             n_all_parameters = self.n_parameters
@@ -1163,7 +1163,7 @@ class FisherInformation:
 
                         else:  # Off-diagonal, same event
                             covariance_inputs[i, b1, b2] = (
-                                    weights_benchmark_uncertainties[i, b1] * weights_benchmark_uncertainties[i, b2]
+                                weights_benchmark_uncertainties[i, b1] * weights_benchmark_uncertainties[i, b2]
                             )
 
             # Jacobian
@@ -1179,8 +1179,12 @@ class FisherInformation:
             covariance_information_phys = np.einsum("ijnb,nbc,klnc->ijkl", jacobian, covariance_inputs, jacobian)
 
             if include_nuisance_parameters:
-                covariance_information = np.zeros((n_all_parameters, n_all_parameters))
-                covariance_information[: self.n_parameters, : self.n_parameters] = covariance_information_phys
+                covariance_information = np.zeros(
+                    (n_all_parameters, n_all_parameters, n_all_parameters, n_all_parameters)
+                )
+                covariance_information[
+                    : self.n_parameters, : self.n_parameters, : self.n_parameters, : self.n_parameters
+                ] = covariance_information_phys
             else:
                 covariance_information = covariance_information_phys
 
@@ -1302,14 +1306,14 @@ class FisherInformation:
         return float(eval(observable_definition, variables))
 
     def _calculate_xsec(
-            self,
-            theta=None,
-            cuts=None,
-            efficiency_functions=None,
-            return_benchmark_xsecs=False,
-            return_error=False,
-            include_nuisance_parameters=True,
-            start_event=0,
+        self,
+        theta=None,
+        cuts=None,
+        efficiency_functions=None,
+        return_benchmark_xsecs=False,
+        return_error=False,
+        include_nuisance_parameters=True,
+        start_event=0,
     ):
         """
         Calculates the total cross section for a parameter point.
@@ -1365,7 +1369,7 @@ class FisherInformation:
         xsecs_uncertainty_benchmarks = None
 
         for observations, weights in madminer_event_loader(
-                self.madminer_filename, start=start_event, include_nuisance_parameters=include_nuisance_parameters
+            self.madminer_filename, start=start_event, include_nuisance_parameters=include_nuisance_parameters
         ):
             # Cuts
             cut_filter = [self._pass_cuts(obs_event, cuts) for obs_event in observations]

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -989,7 +989,7 @@ class FisherInformation:
         sum_events=False,
         calculate_uncertainty=False,
         weights_benchmark_uncertainties=None,
-        weights_sampling_benchmark=None
+        weights_sampling_benchmark=None,
     ):
         """
         Low-level function that calculates a list of full Fisher information matrices for a given parameter point and
@@ -1058,30 +1058,34 @@ class FisherInformation:
         # Nuisance parameter Fisher info
         if include_nuisance_parameters:
             if weights_sampling_benchmark is None:
-                weights_sampling_benchmark = weights_benchmarks[:,0]
+                weights_sampling_benchmark = weights_benchmarks[:, 0]
 
-            nuisance_weight_ratio = weights_benchmarks.T[self.benchmark_is_nuisance,:] / weights_sampling_benchmark[np.newaxis,:]
+            nuisance_weight_ratio = (
+                weights_benchmarks.T[self.benchmark_is_nuisance, :] / weights_sampling_benchmark[np.newaxis, :]
+            )
             # Shape (n_nuisance_parameters, n_events)
 
             # grad_i dsigma(x), where i is a nuisance parameter, is given by
             # sigma[np.newaxis, :] * np.log(nuisance_weight_ratio)
 
-            fisher_info_nuisance = luminosity * np.einsum("n,in,jn->nij", sigma, np.log(nuisance_weight_ratio), np.log(nuisance_weight_ratio))
+            fisher_info_nuisance = luminosity * np.einsum(
+                "n,in,jn->nij", sigma, np.log(nuisance_weight_ratio), np.log(nuisance_weight_ratio)
+            )
             fisher_info_mix = luminosity * np.einsum("in,jn->nij", dsigma, np.log(nuisance_weight_ratio))
 
             n_all_parameters = self.n_parameters + self.n_nuisance_parameters
             fisher_info = np.zeros((n_all_parameters, n_all_parameters))
-            fisher_info[:self.n_parameters, :self.n_parameters] = fisher_info_phys
-            fisher_info[:self.n_parameters, self.n_parameters:] = fisher_info_mix
-            fisher_info[self.n_parameters:, :self.n_parameters] = fisher_info_mix.T
-            fisher_info[self.n_parameters:,self.n_parameters:] = fisher_info_nuisance
+            fisher_info[: self.n_parameters, : self.n_parameters] = fisher_info_phys
+            fisher_info[: self.n_parameters, self.n_parameters :] = fisher_info_mix
+            fisher_info[self.n_parameters :, : self.n_parameters] = fisher_info_mix.T
+            fisher_info[self.n_parameters :, self.n_parameters :] = fisher_info_nuisance
 
         else:
             fisher_info = fisher_info_phys
 
         # Error propagation
         if calculate_uncertainty:
-            weights_benchmarks_phys = weights_benchmarks[:,np.logical_not(self.benchmark_is_nuisance)]
+            weights_benchmarks_phys = weights_benchmarks[:, np.logical_not(self.benchmark_is_nuisance)]
 
             n_events = weights_benchmarks_phys.shape[0]
             n_benchmarks = weights_benchmarks_phys.shape[1]

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -201,6 +201,7 @@ class FisherInformation:
             self.n_samples,
             _,
             self.reference_benchmark,
+            _,
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=include_nuisance_parameters)
         self.n_parameters = len(self.parameters)
         self.n_benchmarks = len(self.benchmarks)

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -576,15 +576,9 @@ class FisherInformation:
                 ]
                 covariance_results = [rate_covariance + this_covariance for this_covariance in covariance]
 
-                if include_nuisance_parameters:
-                    fisher_info_results = [info + self._gaussian_constraint_term() for info in fisher_info_results]
-
                 return fisher_info_results, covariance_results
 
             else:
-                if include_nuisance_parameters:
-                    fisher_info_kin += self._gaussian_constraint_term()
-
                 return fisher_info_rate + fisher_info_kin, rate_covariance + covariance
 
         return fisher_info_rate + fisher_info_kin, rate_covariance

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -123,16 +123,16 @@ def profile_information(
         # Draw toys
         information_toys = np.random.multivariate_normal(
             mean=fisher_information.reshape((-1,)),
-            cov=error_propagation_factor * covariance.reshape((n_components ** 2, n_components ** 2)),
+            cov=error_propagation_factor * covariance.reshape(n_components ** 2, n_components ** 2),
             size=error_propagation_n_ensemble,
         )
-        information_toys.reshape((-1, n_components, n_components))
+        information_toys = information_toys.reshape(-1, n_components, n_components)
 
         # Profile each toy
         profiled_information_toys = np.array([_profile(info) for info in information_toys])
 
         # Calculate ensemble covariance
-        toy_covariance = np.cov(profiled_information_toys.reshape((-1, n_remaining_components ** 2)).T)
+        toy_covariance = np.cov(profiled_information_toys.reshape(-1, n_remaining_components ** 2).T)
         toy_covariance = toy_covariance.reshape(
             (n_remaining_components, n_remaining_components, n_remaining_components, n_remaining_components)
         )
@@ -516,7 +516,7 @@ class FisherInformation:
             ):
                 logger.info("Evaluating kinematic Fisher information on batch %s / %s", i_batch + 1, n_batches)
 
-                weights_theta = theta_matrix.dot(weights_benchmarks.T)
+                weights_theta = mdot(theta_matrix, weights_benchmarks)
 
                 # Calculate Fisher info on this batch
                 if model_is_ensemble:
@@ -738,7 +738,7 @@ class FisherInformation:
 
             # Weights at theta
             theta_matrix = get_theta_benchmark_matrix("morphing", theta, self.benchmarks, self.morpher)
-            weight_theta_pilot = theta_matrix.dot(weights_pilot.T)
+            weight_theta_pilot = mdot(theta_matrix, weights_pilot)
 
             # Bin boundaries
             bin_boundaries = weighted_quantile(histo_observables_pilot, quantile_values, weight_theta_pilot)
@@ -1003,7 +1003,7 @@ class FisherInformation:
 
         # Calculate xsecs in bins
         theta_matrix = get_theta_benchmark_matrix("morphing", theta, self.benchmarks, self.morpher)
-        sigma_bins = theta_matrix.dot(weights_benchmarks_bins.T)  # (n_bins,)
+        sigma_bins = mdot(theta_matrix, weights_benchmarks_bins)  # (n_bins,)
 
         # Calculate rate-only Fisher informations in bins
         fisher_info_rate_bins = self._calculate_fisher_information(
@@ -1045,7 +1045,7 @@ class FisherInformation:
         if theta is not None:
             theta_matrix = get_theta_benchmark_matrix("morphing", theta, self.benchmarks, self.morpher)
 
-            weights_theta = theta_matrix.dot(weights_benchmarks.T)
+            weights_theta = mdot(theta_matrix, weights_benchmarks)
 
             return x, weights_theta
 
@@ -1075,7 +1075,7 @@ class FisherInformation:
         weights_thetas = []
         for theta in thetas:
             theta_matrix = get_theta_benchmark_matrix("morphing", theta, self.benchmarks, self.morpher)
-            weights_thetas.append(theta_matrix.dot(weights_benchmarks.T))
+            weights_thetas.append(mdot(theta_matrix, weights_benchmarks))
 
         weights_thetas = np.array(weights_thetas)
 
@@ -1436,8 +1436,8 @@ class FisherInformation:
 
         # Translate to xsec for theta
         theta_matrix = get_theta_benchmark_matrix("morphing", theta, self.benchmarks, self.morpher)
-        xsec = theta_matrix.dot(xsecs_benchmarks)
-        xsec_error = theta_matrix.dot(xsecs_uncertainty_benchmarks)
+        xsec = mdot(theta_matrix, xsecs_benchmarks)
+        xsec_error = mdot(theta_matrix, xsecs_uncertainty_benchmarks)
 
         if return_error:
             return xsec, xsec_error

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -43,7 +43,7 @@ def project_information(fisher_information, remaining_components):
     return fisher_information_new
 
 
-def profile_information(fisher_information, remaining_components):
+def profile_information(fisher_information, remaining_components, ):
     """
     Calculates the profiled Fisher information matrix as defined in Appendix A.4 of arXiv:1612.05261.
 
@@ -86,7 +86,7 @@ def profile_information(fisher_information, remaining_components):
     inverse_information_nuisance = np.linalg.inv(information_nuisance)
     profiled_information = information_phys - information_mix.T.dot(inverse_information_nuisance.dot(information_mix))
 
-    return profiled_fisher_information
+    return profiled_information
 
 
 class FisherInformation:

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -201,6 +201,7 @@ class FisherInformation:
             self.observables,
             self.n_samples,
             _,
+            self.reference_benchmark,
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=include_nuisance_parameters)
         self.n_parameters = len(self.parameters)
         self.n_benchmarks = len(self.benchmarks)

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -990,7 +990,6 @@ class FisherInformation:
         sum_events=False,
         calculate_uncertainty=False,
         weights_benchmark_uncertainties=None,
-        weights_sampling_benchmark=None,
     ):
         """
         Low-level function that calculates a list of full Fisher information matrices for a given parameter point and
@@ -1023,11 +1022,6 @@ class FisherInformation:
             If calculate_uncertainty is True, weights_benchmark_uncertainties sets the uncertainties on each entry of
             weights_benchmarks. If None, weights_benchmark_uncertainties = weights_benchmarks is assumed.
 
-        weights_sampling_benchmark : ndarray or None, optional
-            If include_nuisance_parameters is True, this sets the weights at the morphing benchmark. Shape
-            `(n_events,)`. If None, this function assumes that the first benchmark was always used for sampling, i.e.
-            `weights_sampling_benchmark = weights_benchmarks[:, 0]`.
-
         Returns
         -------
         fisher_information : ndarray
@@ -1058,11 +1052,9 @@ class FisherInformation:
 
         # Nuisance parameter Fisher info
         if include_nuisance_parameters:
-            if weights_sampling_benchmark is None:
-                weights_sampling_benchmark = weights_benchmarks[:, 0]
-
+            i_ref_benchmark = list(self.benchmarks.keys()).index(self.reference_benchmark)
             nuisance_weight_ratio = (
-                weights_benchmarks.T[self.benchmark_is_nuisance, :] / weights_sampling_benchmark[np.newaxis, :]
+                weights_benchmarks.T[self.benchmark_is_nuisance, :] / weights_benchmarks[np.newaxis, :, i_ref_benchmark]
             )
             # Shape (n_nuisance_parameters, n_events)
 

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -204,7 +204,7 @@ class FisherInformation:
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=include_nuisance_parameters)
         self.n_parameters = len(self.parameters)
         self.n_benchmarks = len(self.benchmarks)
-        self.n_benchmarks_phys = len(self.benchmarks[np.logical_not(self.benchmark_is_nuisance)])
+        self.n_benchmarks_phys = np.sum(np.logical_not(self.benchmark_is_nuisance))
 
         logging.info("Found %s parameters:", len(self.parameters))
         for key, values in six.iteritems(self.parameters):

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -997,7 +997,7 @@ class FisherInformation:
             Observables with shape `(n_unweighted_samples, n_observables)`.
 
         weights : ndarray
-            If theta is None, benchmark weights with shape  `(n_unweighted_samples, n_benchmarks)` in pb. Otherwise,
+            If theta is None, benchmark weights with shape  `(n_unweighted_samples, n_benchmarks_phys)` in pb. Otherwise,
             weights for the given parameter theta with shape `(n_unweighted_samples,)` in pb.
 
         """
@@ -1100,10 +1100,12 @@ class FisherInformation:
         """
 
         # Get morphing matrices
-        theta_matrix = get_theta_benchmark_matrix("morphing", theta, self.benchmarks, self.morpher)  # (n_benchmarks,)
+        theta_matrix = get_theta_benchmark_matrix(
+            "morphing", theta, self.benchmarks, self.morpher
+        )  # (n_benchmarks_phys,)
         dtheta_matrix = get_dtheta_benchmark_matrix(
             "morphing", theta, self.benchmarks, self.morpher
-        )  # (n_parameters, n_benchmarks)
+        )  # (n_parameters, n_benchmarks_phys)
 
         # Get differential xsec per event, and the derivative wrt to theta
         sigma = mdot(theta_matrix, weights_benchmarks)  # Shape (n_events,)
@@ -1153,7 +1155,7 @@ class FisherInformation:
 
             # Input uncertainties
             if weights_benchmark_uncertainties is None:
-                weights_benchmark_uncertainties = weights_benchmarks_phys  # Shape (n_events, n_benchmarks)
+                weights_benchmark_uncertainties = weights_benchmarks_phys  # Shape (n_events, n_benchmarks_phys)
 
             # Build covariance matrix of inputs
             # We assume full correlation between weights_benchmarks[i, b1] and weights_benchmarks[i, b2]
@@ -1177,7 +1179,7 @@ class FisherInformation:
 
             temp1, temp2, temp3 = sanitize_array(temp1), sanitize_array(temp2), sanitize_array(temp3)
 
-            jacobian = luminosity * (temp1 + temp2 + temp3)  # (n_parameters, n_parameters, n_events, n_benchmarks)
+            jacobian = luminosity * (temp1 + temp2 + temp3)  # (n_parameters, n_parameters, n_events, n_benchmarks_phys)
 
             # Covariance of information
             covariance_information_phys = np.einsum("ijnb,nbc,klnc->ijkl", jacobian, covariance_inputs, jacobian)

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -148,6 +148,7 @@ class FisherInformation:
             self.morphing_matrix,
             self.observables,
             self.n_samples,
+            _
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=include_nuisance_parameters)
         self.n_parameters = len(self.parameters)
         self.n_benchmarks = len(self.benchmarks)

--- a/madminer/fisherinformation.py
+++ b/madminer/fisherinformation.py
@@ -242,7 +242,7 @@ class FisherInformation:
             raise RuntimeError("Did not find morphing setup.")
 
     def calculate_fisher_information_full_truth(
-        self, theta, luminosity=300000.0, cuts=None, efficiency_functions=None, include_nuisance_parameters=False
+        self, theta, luminosity=300000.0, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
     ):
         """
         Calculates the full Fisher information at parton / truth level. This is the information in an idealized
@@ -266,7 +266,7 @@ class FisherInformation:
             component. Default value: None.
 
         include_nuisance_parameters : bool, optional
-            If True, nuisance parameters are taken into account. Default value: False.
+            If True, nuisance parameters are taken into account. Default value: True.
 
         Returns
         -------
@@ -554,7 +554,7 @@ class FisherInformation:
         return fisher_info_rate + fisher_info_kin, rate_covariance
 
     def calculate_fisher_information_rate(
-        self, theta, luminosity, cuts=None, efficiency_functions=None, include_nuisance_parameters=False
+        self, theta, luminosity, cuts=None, efficiency_functions=None, include_nuisance_parameters=True
     ):
         """
         Calculates the Fisher information in a measurement of the total cross section (without any kinematic
@@ -577,7 +577,7 @@ class FisherInformation:
             component. Default value: None.
 
         include_nuisance_parameters : bool, optional
-            If True, nuisance parameters are taken into account. Default value: False.
+            If True, nuisance parameters are taken into account. Default value: True.
 
         Returns
         -------
@@ -1044,7 +1044,7 @@ class FisherInformation:
         theta,
         weights_benchmarks,
         luminosity=300000.0,
-        include_nuisance_parameters=False,
+        include_nuisance_parameters=True,
         sum_events=False,
         calculate_uncertainty=False,
         weights_benchmark_uncertainties=None,
@@ -1065,7 +1065,7 @@ class FisherInformation:
             Luminosity in pb^-1. Default value: 300000.
 
         include_nuisance_parameters : bool, optional
-            If True, nuisance parameters are taken into account. Default value: False.
+            If True, nuisance parameters are taken into account. Default value: True.
 
         sum_events : bool, optional
             If True, returns the summed FIsher information. Otherwise, a list of Fisher
@@ -1301,7 +1301,7 @@ class FisherInformation:
         efficiency_functions=None,
         return_benchmark_xsecs=False,
         return_error=False,
-        include_nuisance_parameters=False,
+        include_nuisance_parameters=True,
         start_event=0,
     ):
         """
@@ -1329,7 +1329,7 @@ class FisherInformation:
 
         include_nuisance_parameters : bool, optional
             If True and if return_benchmark_xsecs is True, the nuisance benchmarks are included in the output. Default
-            value: False.
+            value: True.
 
         start_event : int, optional
             Index of first event in MadMiner file to consider. Default value: 0.

--- a/madminer/lhe.py
+++ b/madminer/lhe.py
@@ -6,7 +6,8 @@ import logging
 
 from madminer.utils.interfaces.madminer_hdf5 import load_benchmarks_from_madminer_file, save_madminer_file_from_lhe
 from madminer.utils.interfaces.lhe import extract_observables_from_lhe_file
-from madminer.utils.various import general_init
+
+logger = logging.getLogger(__name__)
 
 
 class LHEProcessor:
@@ -14,8 +15,6 @@ class LHEProcessor:
 
     def __init__(self, debug=False):
         """ Constructor """
-
-        self.logger = general_init(debug=debug)
 
         # Initialize samples
         self.lhe_sample_filenames = []
@@ -38,7 +37,7 @@ class LHEProcessor:
         self.benchmark_names = load_benchmarks_from_madminer_file(filename)
 
     def add_lhe_sample(self, filename, sampling_benchmark, is_background=False, rescale_factor=1.0):
-        self.logger.info("Adding LHE sample at %s", filename)
+        logger.info("Adding LHE sample at %s", filename)
 
         self.lhe_sample_filenames.append(filename)
         self.is_background.append(is_background)
@@ -47,9 +46,9 @@ class LHEProcessor:
 
     def add_observable(self, name, definition, required=False):
         if required:
-            self.logger.info("Adding required observable %s = %s", name, definition)
+            logger.info("Adding required observable %s = %s", name, definition)
         else:
-            self.logger.info("Adding (not required) observable %s = %s", name, definition)
+            logger.info("Adding (not required) observable %s = %s", name, definition)
 
         self.observables[name] = definition
         self.observables_required[name] = required
@@ -76,9 +75,9 @@ class LHEProcessor:
         """
 
         if required:
-            self.logger.info("Adding required observable %s ", name)
+            logger.info("Adding required observable %s ", name)
         else:
-            self.logger.info("Adding (not required) observable %s ", name)
+            logger.info("Adding (not required) observable %s ", name)
 
         self.observables[name] = fn
         self.observables_required[name] = required
@@ -91,7 +90,7 @@ class LHEProcessor:
             self.lhe_sample_filenames, self.sampling_benchmarks, self.is_background, self.rescale_factor
         ):
 
-            self.logger.info("Analysing LHE sample %s", lhe_file)
+            logger.info("Analysing LHE sample %s", lhe_file)
 
             # Calculate observables and weights
             this_observations, this_weights = extract_observables_from_lhe_file(
@@ -129,9 +128,9 @@ class LHEProcessor:
         ), "Nothing to save!"
 
         if filename_in is None:
-            self.logger.info("Saving HDF5 file to %s", filename_out)
+            logger.info("Saving HDF5 file to %s", filename_out)
         else:
-            self.logger.info("Loading HDF5 data from %s and saving file to %s", filename_in, filename_out)
+            logger.info("Loading HDF5 data from %s and saving file to %s", filename_in, filename_out)
 
         save_madminer_file_from_lhe(
             filename_out, self.observables, self.observations, self.weights, copy_from=filename_in

--- a/madminer/lhe.py
+++ b/madminer/lhe.py
@@ -15,7 +15,7 @@ class LHEProcessor:
     def __init__(self, debug=False):
         """ Constructor """
 
-        general_init(debug=debug)
+        self.logger = general_init(debug=debug)
 
         # Initialize samples
         self.lhe_sample_filenames = []
@@ -38,7 +38,7 @@ class LHEProcessor:
         self.benchmark_names = load_benchmarks_from_madminer_file(filename)
 
     def add_lhe_sample(self, filename, sampling_benchmark, is_background=False, rescale_factor=1.0):
-        logging.info("Adding LHE sample at %s", filename)
+        self.logger.info("Adding LHE sample at %s", filename)
 
         self.lhe_sample_filenames.append(filename)
         self.is_background.append(is_background)
@@ -47,9 +47,9 @@ class LHEProcessor:
 
     def add_observable(self, name, definition, required=False):
         if required:
-            logging.info("Adding required observable %s = %s", name, definition)
+            self.logger.info("Adding required observable %s = %s", name, definition)
         else:
-            logging.info("Adding (not required) observable %s = %s", name, definition)
+            self.logger.info("Adding (not required) observable %s = %s", name, definition)
 
         self.observables[name] = definition
         self.observables_required[name] = required
@@ -76,9 +76,9 @@ class LHEProcessor:
         """
 
         if required:
-            logging.info("Adding required observable %s ", name)
+            self.logger.info("Adding required observable %s ", name)
         else:
-            logging.info("Adding (not required) observable %s ", name)
+            self.logger.info("Adding (not required) observable %s ", name)
 
         self.observables[name] = fn
         self.observables_required[name] = required
@@ -91,7 +91,7 @@ class LHEProcessor:
             self.lhe_sample_filenames, self.sampling_benchmarks, self.is_background, self.rescale_factor
         ):
 
-            logging.info("Analysing LHE sample %s", lhe_file)
+            self.logger.info("Analysing LHE sample %s", lhe_file)
 
             # Calculate observables and weights
             this_observations, this_weights = extract_observables_from_lhe_file(
@@ -129,9 +129,9 @@ class LHEProcessor:
         ), "Nothing to save!"
 
         if filename_in is None:
-            logging.info("Saving HDF5 file to %s", filename_out)
+            self.logger.info("Saving HDF5 file to %s", filename_out)
         else:
-            logging.info("Loading HDF5 data from %s and saving file to %s", filename_in, filename_out)
+            self.logger.info("Loading HDF5 data from %s and saving file to %s", filename_in, filename_out)
 
         save_madminer_file_from_lhe(
             filename_out, self.observables, self.observations, self.weights, copy_from=filename_in

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -42,7 +42,7 @@ class MLForge:
     """
 
     def __init__(self, debug=False):
-        general_init(debug=debug)
+        self.logger = general_init(debug=debug)
 
         self.debug = debug
 
@@ -233,55 +233,55 @@ class MLForge:
 
         """
 
-        logging.info("Starting training")
-        logging.info("  Method:                 %s", method)
-        logging.info("  Training data: x at %s", x_filename)
+        self.logger.info("Starting training")
+        self.logger.info("  Method:                 %s", method)
+        self.logger.info("  Training data: x at %s", x_filename)
         if theta0_filename is not None:
-            logging.info("                 theta0 at %s", theta0_filename)
+            self.logger.info("                 theta0 at %s", theta0_filename)
         if theta1_filename is not None:
-            logging.info("                 theta1 at %s", theta1_filename)
+            self.logger.info("                 theta1 at %s", theta1_filename)
         if y_filename is not None:
-            logging.info("                 y at %s", y_filename)
+            self.logger.info("                 y at %s", y_filename)
         if r_xz_filename is not None:
-            logging.info("                 r_xz at %s", r_xz_filename)
+            self.logger.info("                 r_xz at %s", r_xz_filename)
         if t_xz0_filename is not None:
-            logging.info("                 t_xz (theta0) at  %s", t_xz0_filename)
+            self.logger.info("                 t_xz (theta0) at  %s", t_xz0_filename)
         if t_xz1_filename is not None:
-            logging.info("                 t_xz (theta1) at  %s", t_xz1_filename)
+            self.logger.info("                 t_xz (theta1) at  %s", t_xz1_filename)
         if features is None:
-            logging.info("  Features:               all")
+            self.logger.info("  Features:               all")
         else:
-            logging.info("  Features:               %s", features)
-        logging.info("  Method:                 %s", method)
+            self.logger.info("  Features:               %s", features)
+        self.logger.info("  Method:                 %s", method)
         if method in ["nde", "scandal"]:
-            logging.info("  Neural density est.:    %s", nde_type)
+            self.logger.info("  Neural density est.:    %s", nde_type)
         if method not in ["nde", "scandal"]:
-            logging.info("  Hidden layers:          %s", n_hidden)
+            self.logger.info("  Hidden layers:          %s", n_hidden)
         if method in ["nde", "scandal"]:
-            logging.info("  MAF, number MADEs:      %s", maf_n_mades)
-            logging.info("  MAF, batch norm:        %s", maf_batch_norm)
-            logging.info("  MAF, BN alpha:          %s", maf_batch_norm_alpha)
-            logging.info("  MAF MoG, components:    %s", maf_mog_n_components)
-        logging.info("  Activation function:    %s", activation)
+            self.logger.info("  MAF, number MADEs:      %s", maf_n_mades)
+            self.logger.info("  MAF, batch norm:        %s", maf_batch_norm)
+            self.logger.info("  MAF, BN alpha:          %s", maf_batch_norm_alpha)
+            self.logger.info("  MAF MoG, components:    %s", maf_mog_n_components)
+        self.logger.info("  Activation function:    %s", activation)
         if method in ["cascal", "cascal2", "rascal", "rascal2", "scandal"]:
-            logging.info("  alpha:                  %s", alpha)
-        logging.info("  Batch size:             %s", batch_size)
-        logging.info("  Trainer:                %s", trainer)
-        logging.info("  Epochs:                 %s", n_epochs)
-        logging.info("  Learning rate:          %s initially, decaying to %s", initial_lr, final_lr)
+            self.logger.info("  alpha:                  %s", alpha)
+        self.logger.info("  Batch size:             %s", batch_size)
+        self.logger.info("  Trainer:                %s", trainer)
+        self.logger.info("  Epochs:                 %s", n_epochs)
+        self.logger.info("  Learning rate:          %s initially, decaying to %s", initial_lr, final_lr)
         if trainer == "sgd":
-            logging.info("  Nesterov momentum:      %s", nesterov_momentum)
-        logging.info("  Validation split:       %s", validation_split)
-        logging.info("  Early stopping:         %s", early_stopping)
-        logging.info("  Scale inputs:           %s", scale_inputs)
-        logging.info("  Shuffle labels          %s", shuffle_labels)
+            self.logger.info("  Nesterov momentum:      %s", nesterov_momentum)
+        self.logger.info("  Validation split:       %s", validation_split)
+        self.logger.info("  Early stopping:         %s", early_stopping)
+        self.logger.info("  Scale inputs:           %s", scale_inputs)
+        self.logger.info("  Shuffle labels          %s", shuffle_labels)
         if grad_x_regularization is None:
-            logging.info("  Regularization:         None")
+            self.logger.info("  Regularization:         None")
         else:
-            logging.info("  Regularization:         %s * |grad_x f(x)|^2", grad_x_regularization)
+            self.logger.info("  Regularization:         %s * |grad_x f(x)|^2", grad_x_regularization)
 
         # Load training data
-        logging.info("Loading training data")
+        self.logger.info("Loading training data")
 
         theta0 = load_and_check(theta0_filename)
         theta1 = load_and_check(theta1_filename)
@@ -333,11 +333,11 @@ class MLForge:
         else:
             n_parameters = t_xz0.shape[1]
 
-        logging.info("Found %s samples with %s parameters and %s observables", n_samples, n_parameters, n_observables)
+        self.logger.info("Found %s samples with %s parameters and %s observables", n_samples, n_parameters, n_observables)
 
         # Scale features
         if scale_inputs:
-            logging.info("Rescaling inputs")
+            self.logger.info("Rescaling inputs")
             self.x_scaling_means = np.mean(x, axis=0)
             self.x_scaling_stds = np.maximum(np.std(x, axis=0), 1.0e-6)
             x[:] -= self.x_scaling_means
@@ -346,9 +346,9 @@ class MLForge:
             self.x_scaling_means = np.zeros(n_parameters)
             self.x_scaling_stds = np.ones(n_parameters)
 
-        logging.debug("Observable ranges:")
+        self.logger.debug("Observable ranges:")
         for i in range(n_observables):
-            logging.debug(
+            self.logger.debug(
                 "  x_%s: mean %s, std %s, range %s ... %s",
                 i + 1,
                 np.mean(x[:, i]),
@@ -359,13 +359,13 @@ class MLForge:
 
         # Shuffle labels
         if shuffle_labels:
-            logging.info("Shuffling labels")
+            self.logger.info("Shuffling labels")
             y, r_xz, t_xz0, t_xz1 = shuffle(y, r_xz, t_xz0, t_xz1)
 
         # Features
         if features is not None:
             x = x[:, features]
-            logging.info("Only using %s of %s observables", x.shape[1], n_observables)
+            self.logger.info("Only using %s of %s observables", x.shape[1], n_observables)
             n_observables = x.shape[1]
 
         # Save setup
@@ -380,7 +380,7 @@ class MLForge:
         self.features = features
 
         # Create model
-        logging.info("Creating model for method %s", method)
+        self.logger.info("Creating model for method %s", method)
         if method in ["carl", "rolr", "rascal", "alice", "alices"]:
             self.method_type = "parameterized"
             self.model = ParameterizedRatioEstimator(
@@ -479,7 +479,7 @@ class MLForge:
             raise NotImplementedError("Unknown method {}".format(method))
 
         # Train model
-        logging.info("Training model")
+        self.logger.info("Training model")
 
         if method in ["sally", "sallino"]:
             train_local_score_model(
@@ -622,7 +622,7 @@ class MLForge:
             raise ValueError("No model -- train or load model before evaluating it!")
 
         # Load training data
-        logging.debug("Loading evaluation data")
+        self.logger.debug("Loading evaluation data")
 
         theta0s = load_and_check(theta0_filename)
         theta1s = load_and_check(theta1_filename)
@@ -641,7 +641,7 @@ class MLForge:
 
         # SALLY evaluation
         if self.method in ["sally", "sallino"]:
-            logging.debug("Starting score evaluation")
+            self.logger.debug("Starting score evaluation")
 
             if return_grad_x:
                 all_t_hat, all_x_gradients = evaluate_local_score_model(model=self.model, xs=x, return_grad_x=True)
@@ -668,10 +668,10 @@ class MLForge:
         all_x_gradients = []
 
         if test_all_combinations:
-            logging.debug("Starting ratio evaluation for all combinations")
+            self.logger.debug("Starting ratio evaluation for all combinations")
 
             for i, (theta0, theta1) in enumerate(zip(theta0s, theta1s)):
-                logging.debug(
+                self.logger.debug(
                     "Starting ratio evaluation for thetas %s / %s: %s vs %s", i + 1, len(theta0s), theta0, theta1
                 )
 
@@ -716,7 +716,7 @@ class MLForge:
                 all_x_gradients = np.array(all_x_gradients)
 
         else:
-            logging.debug("Starting ratio evaluation")
+            self.logger.debug("Starting ratio evaluation")
 
             if self.method in ["nde", "scandal"]:
                 _, all_log_r_hat, t_hat0 = evaluate_flow_model(
@@ -746,7 +746,7 @@ class MLForge:
                     )
                     all_x_gradients = None
 
-        logging.debug("Evaluation done")
+        self.logger.debug("Evaluation done")
 
         if return_grad_x:
             return all_log_r_hat, all_t_hat0, all_t_hat1, all_x_gradients
@@ -782,7 +782,7 @@ class MLForge:
             raise ValueError("No model -- train or load model before evaluating it!")
 
         # Load training data
-        logging.debug("Loading evaluation data")
+        self.logger.debug("Loading evaluation data")
         if isinstance(x, six.string_types):
             x = load_and_check(x)
         n_samples = x.shape[0]
@@ -798,7 +798,7 @@ class MLForge:
 
         # Estimate scores
         if self.method in ["sally", "sallino"]:
-            logging.debug("Starting score evaluation")
+            self.logger.debug("Starting score evaluation")
 
             t_hats = evaluate_local_score_model(model=self.model, xs=x)
         else:
@@ -814,7 +814,7 @@ class MLForge:
 
         # Calculate expected score
         expected_score = np.mean(t_hats, axis=0)
-        logging.info("Expected per-event score (should be close to zero): %s", expected_score)
+        self.logger.info("Expected per-event score (should be close to zero): %s", expected_score)
 
         return fisher_information
 
@@ -842,7 +842,7 @@ class MLForge:
         create_missing_folders([os.path.dirname(filename)])
 
         # Save settings
-        logging.debug("Saving settings to %s_settings.json", filename)
+        self.logger.debug("Saving settings to %s_settings.json", filename)
 
         settings = {
             "method": self.method,
@@ -859,12 +859,12 @@ class MLForge:
 
         # Save scaling
         if self.x_scaling_stds is not None and self.x_scaling_means is not None:
-            logging.debug("Saving input scaling information to %s_x_means.npy and %s_x_stds.npy", filename, filename)
+            self.logger.debug("Saving input scaling information to %s_x_means.npy and %s_x_stds.npy", filename, filename)
             np.save(filename + "_x_means.npy", self.x_scaling_means)
             np.save(filename + "_x_stds.npy", self.x_scaling_stds)
 
         # Save state dict
-        logging.debug("Saving state dictionary to %s_state_dict.pt", filename)
+        self.logger.debug("Saving state dictionary to %s_state_dict.pt", filename)
         torch.save(self.model.state_dict(), filename + "_state_dict.pt")
 
     def load(self, filename):
@@ -884,7 +884,7 @@ class MLForge:
         """
 
         # Load settings
-        logging.debug("Loading settings from %s_settings.json", filename)
+        self.logger.debug("Loading settings from %s_settings.json", filename)
 
         with open(filename + "_settings.json", "r") as f:
             settings = json.load(f)
@@ -901,7 +901,7 @@ class MLForge:
         if self.features is not None:
             self.features = list([int(item) for item in self.features])
 
-        logging.debug(
+        self.logger.debug(
             "  Found method %s, %s observables, %s parameters, %s hidden layers, %s activation function, "
             "features %s",
             self.method,
@@ -916,11 +916,11 @@ class MLForge:
         try:
             self.x_scaling_means = np.load(filename + "_x_means.npy")
             self.x_scaling_stds = np.load(filename + "_x_stds.npy")
-            logging.debug(
+            self.logger.debug(
                 "  Found input scaling information: means %s, stds %s", self.x_scaling_means, self.x_scaling_stds
             )
         except FileNotFoundError:
-            logging.warning("Scaling information not found in %s", filename)
+            self.logger.warning("Scaling information not found in %s", filename)
             self.x_scaling_means = None
             self.x_scaling_stds = None
 
@@ -953,7 +953,7 @@ class MLForge:
             raise NotImplementedError("Unknown method {}".format(self.method))
 
         # Load state dict
-        logging.debug("Loading state dictionary from %s_state_dict.pt", filename)
+        self.logger.debug("Loading state dictionary from %s_state_dict.pt", filename)
         self.model.load_state_dict(torch.load(filename + "_state_dict.pt"))
 
 
@@ -1002,7 +1002,7 @@ class EnsembleForge:
     """
 
     def __init__(self, estimators=None, debug=False):
-        general_init(debug=debug)
+        self.logger = general_init(debug=debug)
         self.debug = debug
         self.n_parameters = None
         self.n_observables = None
@@ -1097,7 +1097,7 @@ class EnsembleForge:
             None
 
         """
-        logging.info("Training %s estimators in ensemble", self.n_estimators)
+        self.logger.info("Training %s estimators in ensemble", self.n_estimators)
 
         for key, value in six.iteritems(kwargs):
             if not isinstance(value, list):
@@ -1112,7 +1112,7 @@ class EnsembleForge:
             for key, value in six.iteritems(kwargs):
                 kwargs_this_estimator[key] = value[i]
 
-            logging.info("Training estimator %s / %s in ensemble", i + 1, self.n_estimators)
+            self.logger.info("Training estimator %s / %s in ensemble", i + 1, self.n_estimators)
             estimator.train(**kwargs_this_estimator)
 
     def calculate_expectation(self, x_filename, theta0_filename=None, theta1_filename=None):
@@ -1144,13 +1144,13 @@ class EnsembleForge:
 
         """
 
-        logging.info("Calculating expectation for %s estimators in ensemble", self.n_estimators)
+        self.logger.info("Calculating expectation for %s estimators in ensemble", self.n_estimators)
 
         self.expectations = []
         method_type = self._check_consistency()
 
         for i, estimator in enumerate(self.estimators):
-            logging.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
+            self.logger.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
             # Calculate expected score / ratio
             if method_type == "local_score":
@@ -1240,7 +1240,7 @@ class EnsembleForge:
             Only returned if return_individual_predictions is True. The individual estimator predictions.
 
         """
-        logging.info("Evaluating %s estimators in ensemble", self.n_estimators)
+        self.logger.info("Evaluating %s estimators in ensemble", self.n_estimators)
 
         # Calculate weights of each estimator in vote
         if self.expectations is None or vote_expectation_weight is None:
@@ -1265,12 +1265,12 @@ class EnsembleForge:
                 these_weights /= np.sum(these_weights)
                 weights.append(these_weights)
 
-        logging.debug("  Estimator weights: %s", weights)
+        self.logger.debug("  Estimator weights: %s", weights)
 
         # Calculate estimator predictions
         predictions = []
         for i, estimator in enumerate(self.estimators):
-            logging.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
+            self.logger.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
             predictions.append(
                 estimator.evaluate(
@@ -1384,7 +1384,7 @@ class EnsembleForge:
             Only returned if return_individual_predictions is True. The individual estimator predictions.
 
         """
-        logging.debug("Evaluating Fisher information for %s estimators in ensemble", self.n_estimators)
+        self.logger.debug("Evaluating Fisher information for %s estimators in ensemble", self.n_estimators)
 
         # Check input
         if mode not in ["score", "information"]:
@@ -1422,14 +1422,14 @@ class EnsembleForge:
                 these_weights /= np.sum(these_weights)
                 estimator_weights.append(these_weights)
 
-        logging.debug("  Estimator estimator_weights: %s", estimator_weights)
+        self.logger.debug("  Estimator estimator_weights: %s", estimator_weights)
 
         # "information" mode
         if mode == "information":
             # Calculate estimator predictions
             predictions = []
             for i, estimator in enumerate(self.estimators):
-                logging.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
+                self.logger.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
                 predictions.append(estimator.calculate_fisher_information(x=x, weights=obs_weights, n_events=n_events))
             predictions = np.array(predictions)
@@ -1464,13 +1464,14 @@ class EnsembleForge:
             # Calculate score predictions
             score_predictions = []
             for i, estimator in enumerate(self.estimators):
-                logging.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
+                self.logger.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
                 score_predictions.append(estimator.evaluate(x=x))
             score_predictions = np.array(score_predictions)  # (n_estimators, n_events, n_parameters)
 
             # Get ensemble mean and ensemble covariance
             score_mean = np.mean(score_predictions, axis=0)  # (n_events, n_parameters)
+
             score_pred_minus_ens_mean = (
                 score_predictions[:, :, :] - score_mean[np.newaxis, :, :]
             )  # (n_estimators, n_events, n_parameters)
@@ -1478,7 +1479,11 @@ class EnsembleForge:
                 1.0
                 / (self.n_estimators - 1.0)
                 * np.einsum("eni,enj->nij", score_pred_minus_ens_mean, score_pred_minus_ens_mean)
-            )  # (n_events, n_parameters, n_parameters)
+            )
+
+            self.logger.debug("Individual score predictions:\n %s", score_predictions[:,0,:])
+            self.logger.debug("Mean:\n%s", score_mean[0,:])
+            self.logger.debug("Covariance:\n%s", score_cov[0,:,:])
 
             # Event-wise Fisher info
             event_information_mean = np.einsum("ni,nj->nij", score_mean, score_mean)
@@ -1503,7 +1508,7 @@ class EnsembleForge:
             # Let's check the expected score
             expected_score = [np.einsum("n,ni->i", obs_weights, score_mean)]
             expected_score_cov = [np.einsum("n,nij->ij", obs_weights, score_cov)]
-            logging.info("Expected per-event score (should be close to zero):\n%s\nwith covariance matrix\n%s",
+            self.logger.info("Expected per-event score (should be close to zero):\n%s\nwith covariance matrix\n%s",
                          expected_score, expected_score_cov)
 
 
@@ -1557,7 +1562,7 @@ class EnsembleForge:
         create_missing_folders([folder])
 
         # Save ensemble settings
-        logging.debug("Saving ensemble setup to %s/ensemble.json", folder)
+        self.logger.debug("Saving ensemble setup to %s/ensemble.json", folder)
 
         if self.expectations is None:
             expectations = "None"
@@ -1589,7 +1594,7 @@ class EnsembleForge:
         """
 
         # Load ensemble settings
-        logging.debug("Loading ensemble setup from %s/ensemble.json", folder)
+        self.logger.debug("Loading ensemble setup from %s/ensemble.json", folder)
 
         with open(folder + "/ensemble.json", "r") as f:
             settings = json.load(f)
@@ -1601,12 +1606,12 @@ class EnsembleForge:
         if self.expectations is not None:
             self.expectations = np.array(self.expectations)
 
-        logging.info("Found ensemble with %s estimators and expectations %s", self.n_estimators, self.expectations)
+        self.logger.info("Found ensemble with %s estimators and expectations %s", self.n_estimators, self.expectations)
 
         # Load estimators
         self.estimators = []
         for i in range(self.n_estimators):
-            estimator = MLForge()
+            estimator = MLForge(debug=self.debug)
             estimator.load(folder + "/estimator_" + str(i))
             self.estimators.append(estimator)
 

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -20,6 +20,7 @@ from madminer.utils.various import create_missing_folders, load_and_check, shuff
 
 logger = logging.getLogger(__name__)
 
+
 class MLForge:
     """
     Estimating likelihood ratios and scores with machine learning.
@@ -1479,9 +1480,9 @@ class EnsembleForge:
                 * np.einsum("eni,enj->nij", score_pred_minus_ens_mean, score_pred_minus_ens_mean)
             )
 
-            logger.debug("Individual score predictions for first event:\n %s", score_predictions[:,0,:])
-            logger.debug("Mean:\n%s", score_mean[0,:])
-            logger.debug("Covariance:\n%s", score_cov[0,:,:])
+            logger.debug("Individual score predictions for first event:\n %s", score_predictions[:, 0, :])
+            logger.debug("Mean:\n%s", score_mean[0, :])
+            logger.debug("Covariance:\n%s", score_cov[0, :, :])
 
             # Event-wise Fisher info
             event_information_mean = np.einsum("ni,nj->nij", score_mean, score_mean)
@@ -1506,9 +1507,11 @@ class EnsembleForge:
             # Let's check the expected score
             expected_score = [np.einsum("n,ni->i", obs_weights, score_mean)]
             expected_score_cov = [np.einsum("n,nij->ij", obs_weights, score_cov)]
-            logger.info("Expected per-event score (should be close to zero):\n%s\nwith covariance matrix\n%s",
-                         expected_score, expected_score_cov)
-
+            logger.info(
+                "Expected per-event score (should be close to zero):\n%s\nwith covariance matrix\n%s",
+                expected_score,
+                expected_score_cov,
+            )
 
         # Calculate ensemble expectation
         expectation_covariances = None

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -1481,7 +1481,7 @@ class EnsembleForge:
                 * np.einsum("eni,enj->nij", score_pred_minus_ens_mean, score_pred_minus_ens_mean)
             )
 
-            self.logger.debug("Individual score predictions:\n %s", score_predictions[:,0,:])
+            self.logger.debug("Individual score predictions for first event:\n %s", score_predictions[:,0,:])
             self.logger.debug("Mean:\n%s", score_mean[0,:])
             self.logger.debug("Covariance:\n%s", score_cov[0,:,:])
 

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -1603,6 +1603,9 @@ class EnsembleForge:
             estimator.load(folder + "/estimator_" + str(i))
             self.estimators.append(estimator)
 
+        # Check consistency and update n_parameters, n_observables
+        self._check_consistency()
+
     def _check_consistency(self, keywords=None):
         """
         Internal function that checks if all estimators belong to the same category

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -16,8 +16,9 @@ from madminer.utils.ml.models.score import LocalScoreEstimator
 from madminer.utils.ml.flow_trainer import train_flow_model, evaluate_flow_model
 from madminer.utils.ml.ratio_trainer import train_ratio_model, evaluate_ratio_model
 from madminer.utils.ml.score_trainer import train_local_score_model, evaluate_local_score_model
-from madminer.utils.various import create_missing_folders, load_and_check, general_init, shuffle
+from madminer.utils.various import create_missing_folders, load_and_check, shuffle
 
+logger = logging.getLogger(__name__)
 
 class MLForge:
     """
@@ -42,8 +43,6 @@ class MLForge:
     """
 
     def __init__(self, debug=False):
-        self.logger = general_init(debug=debug)
-
         self.debug = debug
 
         self.method_type = None
@@ -233,55 +232,55 @@ class MLForge:
 
         """
 
-        self.logger.info("Starting training")
-        self.logger.info("  Method:                 %s", method)
-        self.logger.info("  Training data: x at %s", x_filename)
+        logger.info("Starting training")
+        logger.info("  Method:                 %s", method)
+        logger.info("  Training data: x at %s", x_filename)
         if theta0_filename is not None:
-            self.logger.info("                 theta0 at %s", theta0_filename)
+            logger.info("                 theta0 at %s", theta0_filename)
         if theta1_filename is not None:
-            self.logger.info("                 theta1 at %s", theta1_filename)
+            logger.info("                 theta1 at %s", theta1_filename)
         if y_filename is not None:
-            self.logger.info("                 y at %s", y_filename)
+            logger.info("                 y at %s", y_filename)
         if r_xz_filename is not None:
-            self.logger.info("                 r_xz at %s", r_xz_filename)
+            logger.info("                 r_xz at %s", r_xz_filename)
         if t_xz0_filename is not None:
-            self.logger.info("                 t_xz (theta0) at  %s", t_xz0_filename)
+            logger.info("                 t_xz (theta0) at  %s", t_xz0_filename)
         if t_xz1_filename is not None:
-            self.logger.info("                 t_xz (theta1) at  %s", t_xz1_filename)
+            logger.info("                 t_xz (theta1) at  %s", t_xz1_filename)
         if features is None:
-            self.logger.info("  Features:               all")
+            logger.info("  Features:               all")
         else:
-            self.logger.info("  Features:               %s", features)
-        self.logger.info("  Method:                 %s", method)
+            logger.info("  Features:               %s", features)
+        logger.info("  Method:                 %s", method)
         if method in ["nde", "scandal"]:
-            self.logger.info("  Neural density est.:    %s", nde_type)
+            logger.info("  Neural density est.:    %s", nde_type)
         if method not in ["nde", "scandal"]:
-            self.logger.info("  Hidden layers:          %s", n_hidden)
+            logger.info("  Hidden layers:          %s", n_hidden)
         if method in ["nde", "scandal"]:
-            self.logger.info("  MAF, number MADEs:      %s", maf_n_mades)
-            self.logger.info("  MAF, batch norm:        %s", maf_batch_norm)
-            self.logger.info("  MAF, BN alpha:          %s", maf_batch_norm_alpha)
-            self.logger.info("  MAF MoG, components:    %s", maf_mog_n_components)
-        self.logger.info("  Activation function:    %s", activation)
+            logger.info("  MAF, number MADEs:      %s", maf_n_mades)
+            logger.info("  MAF, batch norm:        %s", maf_batch_norm)
+            logger.info("  MAF, BN alpha:          %s", maf_batch_norm_alpha)
+            logger.info("  MAF MoG, components:    %s", maf_mog_n_components)
+        logger.info("  Activation function:    %s", activation)
         if method in ["cascal", "cascal2", "rascal", "rascal2", "scandal"]:
-            self.logger.info("  alpha:                  %s", alpha)
-        self.logger.info("  Batch size:             %s", batch_size)
-        self.logger.info("  Trainer:                %s", trainer)
-        self.logger.info("  Epochs:                 %s", n_epochs)
-        self.logger.info("  Learning rate:          %s initially, decaying to %s", initial_lr, final_lr)
+            logger.info("  alpha:                  %s", alpha)
+        logger.info("  Batch size:             %s", batch_size)
+        logger.info("  Trainer:                %s", trainer)
+        logger.info("  Epochs:                 %s", n_epochs)
+        logger.info("  Learning rate:          %s initially, decaying to %s", initial_lr, final_lr)
         if trainer == "sgd":
-            self.logger.info("  Nesterov momentum:      %s", nesterov_momentum)
-        self.logger.info("  Validation split:       %s", validation_split)
-        self.logger.info("  Early stopping:         %s", early_stopping)
-        self.logger.info("  Scale inputs:           %s", scale_inputs)
-        self.logger.info("  Shuffle labels          %s", shuffle_labels)
+            logger.info("  Nesterov momentum:      %s", nesterov_momentum)
+        logger.info("  Validation split:       %s", validation_split)
+        logger.info("  Early stopping:         %s", early_stopping)
+        logger.info("  Scale inputs:           %s", scale_inputs)
+        logger.info("  Shuffle labels          %s", shuffle_labels)
         if grad_x_regularization is None:
-            self.logger.info("  Regularization:         None")
+            logger.info("  Regularization:         None")
         else:
-            self.logger.info("  Regularization:         %s * |grad_x f(x)|^2", grad_x_regularization)
+            logger.info("  Regularization:         %s * |grad_x f(x)|^2", grad_x_regularization)
 
         # Load training data
-        self.logger.info("Loading training data")
+        logger.info("Loading training data")
 
         theta0 = load_and_check(theta0_filename)
         theta1 = load_and_check(theta1_filename)
@@ -333,11 +332,11 @@ class MLForge:
         else:
             n_parameters = t_xz0.shape[1]
 
-        self.logger.info("Found %s samples with %s parameters and %s observables", n_samples, n_parameters, n_observables)
+        logger.info("Found %s samples with %s parameters and %s observables", n_samples, n_parameters, n_observables)
 
         # Scale features
         if scale_inputs:
-            self.logger.info("Rescaling inputs")
+            logger.info("Rescaling inputs")
             self.x_scaling_means = np.mean(x, axis=0)
             self.x_scaling_stds = np.maximum(np.std(x, axis=0), 1.0e-6)
             x[:] -= self.x_scaling_means
@@ -346,9 +345,9 @@ class MLForge:
             self.x_scaling_means = np.zeros(n_parameters)
             self.x_scaling_stds = np.ones(n_parameters)
 
-        self.logger.debug("Observable ranges:")
+        logger.debug("Observable ranges:")
         for i in range(n_observables):
-            self.logger.debug(
+            logger.debug(
                 "  x_%s: mean %s, std %s, range %s ... %s",
                 i + 1,
                 np.mean(x[:, i]),
@@ -359,13 +358,13 @@ class MLForge:
 
         # Shuffle labels
         if shuffle_labels:
-            self.logger.info("Shuffling labels")
+            logger.info("Shuffling labels")
             y, r_xz, t_xz0, t_xz1 = shuffle(y, r_xz, t_xz0, t_xz1)
 
         # Features
         if features is not None:
             x = x[:, features]
-            self.logger.info("Only using %s of %s observables", x.shape[1], n_observables)
+            logger.info("Only using %s of %s observables", x.shape[1], n_observables)
             n_observables = x.shape[1]
 
         # Save setup
@@ -380,7 +379,7 @@ class MLForge:
         self.features = features
 
         # Create model
-        self.logger.info("Creating model for method %s", method)
+        logger.info("Creating model for method %s", method)
         if method in ["carl", "rolr", "rascal", "alice", "alices"]:
             self.method_type = "parameterized"
             self.model = ParameterizedRatioEstimator(
@@ -479,7 +478,7 @@ class MLForge:
             raise NotImplementedError("Unknown method {}".format(method))
 
         # Train model
-        self.logger.info("Training model")
+        logger.info("Training model")
 
         if method in ["sally", "sallino"]:
             train_local_score_model(
@@ -622,7 +621,7 @@ class MLForge:
             raise ValueError("No model -- train or load model before evaluating it!")
 
         # Load training data
-        self.logger.debug("Loading evaluation data")
+        logger.debug("Loading evaluation data")
 
         theta0s = load_and_check(theta0_filename)
         theta1s = load_and_check(theta1_filename)
@@ -641,7 +640,7 @@ class MLForge:
 
         # SALLY evaluation
         if self.method in ["sally", "sallino"]:
-            self.logger.debug("Starting score evaluation")
+            logger.debug("Starting score evaluation")
 
             if return_grad_x:
                 all_t_hat, all_x_gradients = evaluate_local_score_model(model=self.model, xs=x, return_grad_x=True)
@@ -668,10 +667,10 @@ class MLForge:
         all_x_gradients = []
 
         if test_all_combinations:
-            self.logger.debug("Starting ratio evaluation for all combinations")
+            logger.debug("Starting ratio evaluation for all combinations")
 
             for i, (theta0, theta1) in enumerate(zip(theta0s, theta1s)):
-                self.logger.debug(
+                logger.debug(
                     "Starting ratio evaluation for thetas %s / %s: %s vs %s", i + 1, len(theta0s), theta0, theta1
                 )
 
@@ -716,7 +715,7 @@ class MLForge:
                 all_x_gradients = np.array(all_x_gradients)
 
         else:
-            self.logger.debug("Starting ratio evaluation")
+            logger.debug("Starting ratio evaluation")
 
             if self.method in ["nde", "scandal"]:
                 _, all_log_r_hat, t_hat0 = evaluate_flow_model(
@@ -746,7 +745,7 @@ class MLForge:
                     )
                     all_x_gradients = None
 
-        self.logger.debug("Evaluation done")
+        logger.debug("Evaluation done")
 
         if return_grad_x:
             return all_log_r_hat, all_t_hat0, all_t_hat1, all_x_gradients
@@ -782,7 +781,7 @@ class MLForge:
             raise ValueError("No model -- train or load model before evaluating it!")
 
         # Load training data
-        self.logger.debug("Loading evaluation data")
+        logger.debug("Loading evaluation data")
         if isinstance(x, six.string_types):
             x = load_and_check(x)
         n_samples = x.shape[0]
@@ -798,7 +797,7 @@ class MLForge:
 
         # Estimate scores
         if self.method in ["sally", "sallino"]:
-            self.logger.debug("Starting score evaluation")
+            logger.debug("Starting score evaluation")
 
             t_hats = evaluate_local_score_model(model=self.model, xs=x)
         else:
@@ -814,7 +813,7 @@ class MLForge:
 
         # Calculate expected score
         expected_score = np.mean(t_hats, axis=0)
-        self.logger.info("Expected per-event score (should be close to zero): %s", expected_score)
+        logger.info("Expected per-event score (should be close to zero): %s", expected_score)
 
         return fisher_information
 
@@ -842,7 +841,7 @@ class MLForge:
         create_missing_folders([os.path.dirname(filename)])
 
         # Save settings
-        self.logger.debug("Saving settings to %s_settings.json", filename)
+        logger.debug("Saving settings to %s_settings.json", filename)
 
         settings = {
             "method": self.method,
@@ -859,12 +858,12 @@ class MLForge:
 
         # Save scaling
         if self.x_scaling_stds is not None and self.x_scaling_means is not None:
-            self.logger.debug("Saving input scaling information to %s_x_means.npy and %s_x_stds.npy", filename, filename)
+            logger.debug("Saving input scaling information to %s_x_means.npy and %s_x_stds.npy", filename, filename)
             np.save(filename + "_x_means.npy", self.x_scaling_means)
             np.save(filename + "_x_stds.npy", self.x_scaling_stds)
 
         # Save state dict
-        self.logger.debug("Saving state dictionary to %s_state_dict.pt", filename)
+        logger.debug("Saving state dictionary to %s_state_dict.pt", filename)
         torch.save(self.model.state_dict(), filename + "_state_dict.pt")
 
     def load(self, filename):
@@ -884,7 +883,7 @@ class MLForge:
         """
 
         # Load settings
-        self.logger.debug("Loading settings from %s_settings.json", filename)
+        logger.debug("Loading settings from %s_settings.json", filename)
 
         with open(filename + "_settings.json", "r") as f:
             settings = json.load(f)
@@ -901,7 +900,7 @@ class MLForge:
         if self.features is not None:
             self.features = list([int(item) for item in self.features])
 
-        self.logger.debug(
+        logger.debug(
             "  Found method %s, %s observables, %s parameters, %s hidden layers, %s activation function, "
             "features %s",
             self.method,
@@ -916,11 +915,11 @@ class MLForge:
         try:
             self.x_scaling_means = np.load(filename + "_x_means.npy")
             self.x_scaling_stds = np.load(filename + "_x_stds.npy")
-            self.logger.debug(
+            logger.debug(
                 "  Found input scaling information: means %s, stds %s", self.x_scaling_means, self.x_scaling_stds
             )
         except FileNotFoundError:
-            self.logger.warning("Scaling information not found in %s", filename)
+            logger.warning("Scaling information not found in %s", filename)
             self.x_scaling_means = None
             self.x_scaling_stds = None
 
@@ -953,7 +952,7 @@ class MLForge:
             raise NotImplementedError("Unknown method {}".format(self.method))
 
         # Load state dict
-        self.logger.debug("Loading state dictionary from %s_state_dict.pt", filename)
+        logger.debug("Loading state dictionary from %s_state_dict.pt", filename)
         self.model.load_state_dict(torch.load(filename + "_state_dict.pt"))
 
 
@@ -1002,7 +1001,6 @@ class EnsembleForge:
     """
 
     def __init__(self, estimators=None, debug=False):
-        self.logger = general_init(debug=debug)
         self.debug = debug
         self.n_parameters = None
         self.n_observables = None
@@ -1097,7 +1095,7 @@ class EnsembleForge:
             None
 
         """
-        self.logger.info("Training %s estimators in ensemble", self.n_estimators)
+        logger.info("Training %s estimators in ensemble", self.n_estimators)
 
         for key, value in six.iteritems(kwargs):
             if not isinstance(value, list):
@@ -1112,7 +1110,7 @@ class EnsembleForge:
             for key, value in six.iteritems(kwargs):
                 kwargs_this_estimator[key] = value[i]
 
-            self.logger.info("Training estimator %s / %s in ensemble", i + 1, self.n_estimators)
+            logger.info("Training estimator %s / %s in ensemble", i + 1, self.n_estimators)
             estimator.train(**kwargs_this_estimator)
 
     def calculate_expectation(self, x_filename, theta0_filename=None, theta1_filename=None):
@@ -1144,13 +1142,13 @@ class EnsembleForge:
 
         """
 
-        self.logger.info("Calculating expectation for %s estimators in ensemble", self.n_estimators)
+        logger.info("Calculating expectation for %s estimators in ensemble", self.n_estimators)
 
         self.expectations = []
         method_type = self._check_consistency()
 
         for i, estimator in enumerate(self.estimators):
-            self.logger.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
+            logger.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
             # Calculate expected score / ratio
             if method_type == "local_score":
@@ -1240,7 +1238,7 @@ class EnsembleForge:
             Only returned if return_individual_predictions is True. The individual estimator predictions.
 
         """
-        self.logger.info("Evaluating %s estimators in ensemble", self.n_estimators)
+        logger.info("Evaluating %s estimators in ensemble", self.n_estimators)
 
         # Calculate weights of each estimator in vote
         if self.expectations is None or vote_expectation_weight is None:
@@ -1265,12 +1263,12 @@ class EnsembleForge:
                 these_weights /= np.sum(these_weights)
                 weights.append(these_weights)
 
-        self.logger.debug("  Estimator weights: %s", weights)
+        logger.debug("  Estimator weights: %s", weights)
 
         # Calculate estimator predictions
         predictions = []
         for i, estimator in enumerate(self.estimators):
-            self.logger.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
+            logger.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
             predictions.append(
                 estimator.evaluate(
@@ -1384,7 +1382,7 @@ class EnsembleForge:
             Only returned if return_individual_predictions is True. The individual estimator predictions.
 
         """
-        self.logger.debug("Evaluating Fisher information for %s estimators in ensemble", self.n_estimators)
+        logger.debug("Evaluating Fisher information for %s estimators in ensemble", self.n_estimators)
 
         # Check input
         if mode not in ["score", "information"]:
@@ -1422,14 +1420,14 @@ class EnsembleForge:
                 these_weights /= np.sum(these_weights)
                 estimator_weights.append(these_weights)
 
-        self.logger.debug("  Estimator estimator_weights: %s", estimator_weights)
+        logger.debug("  Estimator estimator_weights: %s", estimator_weights)
 
         # "information" mode
         if mode == "information":
             # Calculate estimator predictions
             predictions = []
             for i, estimator in enumerate(self.estimators):
-                self.logger.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
+                logger.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
                 predictions.append(estimator.calculate_fisher_information(x=x, weights=obs_weights, n_events=n_events))
             predictions = np.array(predictions)
@@ -1464,7 +1462,7 @@ class EnsembleForge:
             # Calculate score predictions
             score_predictions = []
             for i, estimator in enumerate(self.estimators):
-                self.logger.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
+                logger.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
                 score_predictions.append(estimator.evaluate(x=x))
             score_predictions = np.array(score_predictions)  # (n_estimators, n_events, n_parameters)
@@ -1481,9 +1479,9 @@ class EnsembleForge:
                 * np.einsum("eni,enj->nij", score_pred_minus_ens_mean, score_pred_minus_ens_mean)
             )
 
-            self.logger.debug("Individual score predictions for first event:\n %s", score_predictions[:,0,:])
-            self.logger.debug("Mean:\n%s", score_mean[0,:])
-            self.logger.debug("Covariance:\n%s", score_cov[0,:,:])
+            logger.debug("Individual score predictions for first event:\n %s", score_predictions[:,0,:])
+            logger.debug("Mean:\n%s", score_mean[0,:])
+            logger.debug("Covariance:\n%s", score_cov[0,:,:])
 
             # Event-wise Fisher info
             event_information_mean = np.einsum("ni,nj->nij", score_mean, score_mean)
@@ -1508,7 +1506,7 @@ class EnsembleForge:
             # Let's check the expected score
             expected_score = [np.einsum("n,ni->i", obs_weights, score_mean)]
             expected_score_cov = [np.einsum("n,nij->ij", obs_weights, score_cov)]
-            self.logger.info("Expected per-event score (should be close to zero):\n%s\nwith covariance matrix\n%s",
+            logger.info("Expected per-event score (should be close to zero):\n%s\nwith covariance matrix\n%s",
                          expected_score, expected_score_cov)
 
 
@@ -1562,7 +1560,7 @@ class EnsembleForge:
         create_missing_folders([folder])
 
         # Save ensemble settings
-        self.logger.debug("Saving ensemble setup to %s/ensemble.json", folder)
+        logger.debug("Saving ensemble setup to %s/ensemble.json", folder)
 
         if self.expectations is None:
             expectations = "None"
@@ -1594,7 +1592,7 @@ class EnsembleForge:
         """
 
         # Load ensemble settings
-        self.logger.debug("Loading ensemble setup from %s/ensemble.json", folder)
+        logger.debug("Loading ensemble setup from %s/ensemble.json", folder)
 
         with open(folder + "/ensemble.json", "r") as f:
             settings = json.load(f)
@@ -1606,7 +1604,7 @@ class EnsembleForge:
         if self.expectations is not None:
             self.expectations = np.array(self.expectations)
 
-        self.logger.info("Found ensemble with %s estimators and expectations %s", self.n_estimators, self.expectations)
+        logger.info("Found ensemble with %s estimators and expectations %s", self.n_estimators, self.expectations)
 
         # Load estimators
         self.estimators = []

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -1264,9 +1264,10 @@ class EnsembleForge:
                 these_weights /= np.sum(these_weights)
                 weights.append(these_weights)
 
-        logger.debug("  Estimator weights: %s", weights)
+        logger.debug("Estimator weights: %s", weights)
 
         # Calculate estimator predictions
+        logging.debug("Individual estimator predictions:")
         predictions = []
         for i, estimator in enumerate(self.estimators):
             logger.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
@@ -1276,6 +1277,8 @@ class EnsembleForge:
                     x_filename, theta0_filename, theta1_filename, test_all_combinations, evaluate_score=False
                 )
             )
+
+            logging.debug("Estimator %s predicts %s", i, predictions[-1][0,:])
         predictions = np.array(predictions)
 
         # Calculate weighted means and covariance matrices
@@ -1462,10 +1465,12 @@ class EnsembleForge:
 
             # Calculate score predictions
             score_predictions = []
+            logger.debug("Evaluating estimators for x = %s", x[0,:])
             for i, estimator in enumerate(self.estimators):
                 logger.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
                 score_predictions.append(estimator.evaluate(x=x))
+                logger.debug("Estimator %s predicts t(x) = %s", i, score_predictions[-1][0,:])
             score_predictions = np.array(score_predictions)  # (n_estimators, n_events, n_parameters)
 
             # Get ensemble mean and ensemble covariance

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -1679,7 +1679,7 @@ class EnsembleForge:
                 raise RuntimeError(
                     "Ensemble with inconsistent numbers of parameters for different estimators: %s", all_n_parameters
                 )
-            if self.n_observables is not None and self.n_observables != n_observables:
+            if self.n_observables is not None and self.n_observables != estimator_n_observables:
                 raise RuntimeError(
                     "Ensemble with inconsistent numbers of parameters for different estimators: %s", all_n_observables
                 )

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -814,7 +814,7 @@ class MLForge:
 
         # Calculate expected score
         expected_score = np.mean(t_hats, axis=0)
-        logging.debug("Expected per-event score (should be close to zero): %s", expected_score)
+        logging.info("Expected per-event score (should be close to zero): %s", expected_score)
 
         return fisher_information
 
@@ -1480,7 +1480,7 @@ class EnsembleForge:
                 * np.einsum("eni,enj->nij", score_pred_minus_ens_mean, score_pred_minus_ens_mean)
             )  # (n_events, n_parameters, n_parameters)
 
-            # Event-wise FIsher info
+            # Event-wise Fisher info
             event_information_mean = np.einsum("ni,nj->nij", score_mean, score_mean)
             event_information_cov = (
                 np.einsum("ni,njk,nl->nijkl", score_mean, score_cov, score_mean)
@@ -1499,6 +1499,13 @@ class EnsembleForge:
 
             # Propagate uncertainty to Fisher information
             ensemble_covariances = [float(n_events) * np.einsum("n,nijkl->ijkl", obs_weights, event_information_cov)]
+
+            # Let's check the expected score
+            expected_score = [np.einsum("n,ni->i", obs_weights, score_mean)]
+            expected_score_cov = [np.einsum("n,nij->ij", obs_weights, score_cov)]
+            logging.info("Expected per-event score (should be close to zero):\n%s\nwith covariance matrix\n%s",
+                         expected_score, expected_score_cov)
+
 
         # Calculate ensemble expectation
         expectation_covariances = None

--- a/madminer/ml.py
+++ b/madminer/ml.py
@@ -1271,7 +1271,6 @@ class EnsembleForge:
         logger.debug("Estimator weights: %s", weights)
 
         # Calculate estimator predictions
-        logger.debug("Individual estimator predictions:")
         predictions = []
         for i, estimator in enumerate(self.estimators):
             logger.info("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
@@ -1282,7 +1281,7 @@ class EnsembleForge:
                 )
             )
 
-            logger.debug("Estimator %s predicts %s", i, predictions[-1][0, :])
+            logger.debug("Estimator %s predicts %s for first event", i + 1, predictions[-1][0, :])
         predictions = np.array(predictions)
 
         # Calculate weighted means and covariance matrices
@@ -1469,12 +1468,11 @@ class EnsembleForge:
 
             # Calculate score predictions
             score_predictions = []
-            logger.debug("Evaluating estimators for x = %s", x[0, :])
             for i, estimator in enumerate(self.estimators):
                 logger.debug("Starting evaluation for estimator %s / %s in ensemble", i + 1, self.n_estimators)
 
                 score_predictions.append(estimator.evaluate(x=x))
-                logger.debug("Estimator %s predicts t(x) = %s", i, score_predictions[-1][0, :])
+                logger.debug("Estimator %s predicts t(x) = %s for first event", i + 1, score_predictions[-1][0, :])
             score_predictions = np.array(score_predictions)  # (n_estimators, n_events, n_parameters)
 
             logger.debug("Now x = %s", x[0, :])
@@ -1491,8 +1489,7 @@ class EnsembleForge:
                 * np.einsum("eni,enj->nij", score_pred_minus_ens_mean, score_pred_minus_ens_mean)
             )
 
-            logger.debug("Individual score predictions for first event:\n %s", score_predictions[:, 0, :])
-            logger.debug("Mean:\n%s", score_mean[0, :])
+            logger.debug("Mean score for first event: %s", score_mean[0, :])
             logger.debug("Covariance:\n%s", score_cov[0, :, :])
 
             # Event-wise Fisher info

--- a/madminer/morphing.py
+++ b/madminer/morphing.py
@@ -152,7 +152,7 @@ class Morpher:
             this_max_overall_power = max_overall_power[i]
             powers_each_component = [range(max_power[i] + 1) for max_power in self.parameter_max_power]
 
-            logging.debug(
+            logger.debug(
                 "Region %s: max overall power %s, max individual powers %s",
                 i,
                 this_max_overall_power,
@@ -166,10 +166,10 @@ class Morpher:
                     continue
 
                 if not any((powers == x).all() for x in components):
-                    logging.debug("  Adding component %s", powers)
+                    logger.debug("  Adding component %s", powers)
                     components.append(np.copy(powers))
                 else:
-                    logging.debug("  Not adding component %s again", powers)
+                    logger.debug("  Not adding component %s again", powers)
 
         self.components = np.array(components, dtype=np.int)
         self.n_components = len(self.components)

--- a/madminer/morphing.py
+++ b/madminer/morphing.py
@@ -720,7 +720,7 @@ class NuisanceMorpher:
 
         for i_pos, i_neg, degree in zip(self.i_benchmarks_pos, self.i_benchmarks_neg, self.degrees):
             if degree == 1:
-                b.append(0.0)
+                b.append(np.zeros(benchmark_weights.shape[0]))
             elif degree == 2:
                 b.append(
                     0.5

--- a/madminer/morphing.py
+++ b/madminer/morphing.py
@@ -6,6 +6,8 @@ import numpy as np
 from collections import OrderedDict
 import itertools
 
+from madminer.utils.various import sanitize_array
+
 logger = logging.getLogger(__name__)
 
 
@@ -695,6 +697,7 @@ class NuisanceMorpher:
                 a.append(0.5 * np.log(benchmark_weights[:, i_pos] / benchmark_weights[:, i_neg]))
 
         a = np.array(a)  # Shape (n_nuisance_parameters, n_events)
+        a = sanitize_array(a, min_value=-10., max_value=10.)
         return a
 
     def calculate_b(self, benchmark_weights):
@@ -732,6 +735,7 @@ class NuisanceMorpher:
                 )
 
         b = np.array(b)  # Shape (n_nuisance_parameters, n_events)
+        b = sanitize_array(b, min_value=-10., max_value=10.)
         return b
 
     def calculate_nuisance_factors(self, nuisance_parameters, benchmark_weights):

--- a/madminer/morphing.py
+++ b/madminer/morphing.py
@@ -6,6 +6,8 @@ import numpy as np
 from collections import OrderedDict
 import itertools
 
+logger = logging.getLogger(__name__)
+
 
 class Morpher:
     """

--- a/madminer/morphing.py
+++ b/madminer/morphing.py
@@ -620,3 +620,34 @@ class Morpher:
         thetas = self.parameter_range[:, 0] + u * (self.parameter_range[:, 1] - self.parameter_range[:, 0])
 
         return thetas
+
+
+def calculate_nuisance_factors(nuisance_parameters, reference_benchmark_weights, nuisance_benchmark_weights):
+    """
+    Calculates the rescaling of the event weights from non-central values of nuisance parameters.
+
+    Parameters
+    ----------
+    nuisance_parameters : ndarray
+        Values of the nuisance parameters `nu`, with shape `(n_events, n_nuisance_parameters)`.
+
+    reference_benchmark_weights : ndarray
+        Event weights `dsigma(x |  theta_reference, 0)`. Has shape `(n_events, )`.
+
+    nuisance_benchmark_weights : ndarray
+        Event weights `dsigma(x |  theta_reference, nu_i)` where `nu_i` is 0 except for the `i`th component, which is 1.
+        Has shape `(n_events, n_nuisance_parameters)`.
+
+    Returns
+    -------
+    nuisance_factors : ndarray
+        Nuisance factor `dsigma(x |  theta, nu) / dsigma(x | theta, 0)` with shape `(n_events,)`.
+
+    """
+
+    log_nuisance_ratio = np.log(nuisance_benchmark_weights / reference_benchmark_weights[:, np.newaxis])
+    # Shape (n_events, n_nuisance_parameters)
+
+    exponent = np.sum(log_nuisance_ratio * nuisance_parameters, axis=1)
+
+    return np.exp(exponent)

--- a/madminer/morphing.py
+++ b/madminer/morphing.py
@@ -365,7 +365,7 @@ class Morpher:
         n_bases = n_benchmarks // self.n_components
         assert n_bases * self.n_components == n_benchmarks, "Basis and number of components incompatible!"
 
-        # Full morphing matrix. Will have shape (n_components, n_benchmarks) (note transposition later)
+        # Full morphing matrix. Will have shape (n_components, n_benchmarks_phys) (note transposition later)
         morphing_matrix = np.zeros((n_benchmarks, self.n_components))
 
         # Morphing submatrix for each basis
@@ -518,7 +518,9 @@ class Morpher:
                 component_weight_gradients[c, i] = factor
 
         # Transform to basis weights
-        weight_gradients = morphing_matrix.T.dot(component_weight_gradients).T  # Shape (n_parameters, n_benchmarks)
+        weight_gradients = morphing_matrix.T.dot(
+            component_weight_gradients
+        ).T  # Shape (n_parameters, n_benchmarks_phys)
 
         return weight_gradients
 

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -89,11 +89,12 @@ def plot_distributions(
 
     # Load data
     sa = SampleAugmenter(filename, include_nuisance_parameters=True)
-    morpher = NuisanceMorpher(
-        sa.nuisance_parameters, list(sa.benchmarks.keys()), reference_benchmark=sa.reference_benchmark
-    )
+    if uncertainties == "nuisance":
+        nuisance_morpher = NuisanceMorpher(
+            sa.nuisance_parameters, list(sa.benchmarks.keys()), reference_benchmark=sa.reference_benchmark
+        )
 
-    # Default parameters
+    # Default settings
     if parameter_points is None:
         parameter_points = []
 
@@ -171,18 +172,9 @@ def plot_distributions(
 
         logger.debug("Drew %s toy values for nuisance parameters", n_toys * n_nuisance_params)
 
-        nuisance_filter = np.array(sa.benchmark_is_nuisance, dtype=np.bool)
-        weights_nuisance_benchmarks = weights_benchmarks[:, nuisance_filter]
-
-        i_ref_benchmark = 0
-        if sa.reference_benchmark is not None:
-            i_ref_benchmark = list(sa.benchmarks.keys()).index(sa.reference_benchmark)
-        weights_ref_benchmark = weights_benchmarks[:, i_ref_benchmark]
-        logger.debug("Extracted nuisance benchmark and reference weights")
-
         nuisance_toy_factors = np.array(
             [
-                calculate_nuisance_factors(nuisance_toy, weights_ref_benchmark, weights_nuisance_benchmarks)
+                nuisance_morpher.calculate_nuisance_factors(nuisance_toy, weights_benchmarks)
                 for nuisance_toy in nuisance_toys
             ]
         )  # Shape (n_toys, n_events)

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -8,6 +8,39 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def plot_distributions(madminer_file, observables=None, parameter_points=None, nuisance_points=False):
+    """
+    Plots one-dimensional histograms of observables in a MadMiner file for a given set of benchmarks.
+
+    Parameters
+    ----------
+    madminer_file : str
+        Filename of a MadMiner HDF5 file.
+
+    observables : list of str or None.
+        Which observables to plot, given by a list of their names. If None, all observables in the file
+        are plotted. Default value: None.
+
+    parameter_points : list of (str or ndarray) or None.
+        Which parameter points to use for histogramming the data. Given by a list, each element can either be the name
+        of a benchmark in the MadMiner file, or an ndarray specifying any parameter point in a morphing setup. If None,
+        all physics (non-nuisance) benchmarks defined in the MadMiner file are plotted. Default value: None.
+
+    nuisance_points : list of (str or ndarray) or None.
+        Sets the value of the nuisance parameters for histogramming the data. Given by a list, each element can either
+        be the name of a nuisance benchmark in the MadMiner file, or an ndarray specifying all nuisance parameters. If
+        None, all nuisance parameters are assumed to be at their nominal (central) value.  Default value: None.
+
+    Returns
+    -------
+    figure : Figure
+        Plot as Matplotlib Figure instance.
+
+    """
+
+    return NotImplementedError
+
+
 def plot_2d_morphing_basis(
     morpher,
     xlabel=r"$\theta_0$",

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -147,7 +147,15 @@ def plot_distributions(
 
         for x, lw, color, label, ls in zip(samples, linewidths, colors, line_labels, linestyles):
             plt.hist(
-                x[:, i], histtype="step", range=x_range, bins=n_bins, lw=lw, ls=ls, color=color, label=label, density=True
+                x[:, i],
+                histtype="step",
+                range=x_range,
+                bins=n_bins,
+                lw=lw,
+                ls=ls,
+                color=color,
+                label=label,
+                density=True,
             )
 
         plt.legend()

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -9,7 +9,7 @@ import logging
 from madminer.sampling import SampleAugmenter
 from madminer.utils.analysis import mdot, get_theta_benchmark_matrix
 from madminer.morphing import calculate_nuisance_factors
-from madminer.utils.various import weighted_quantile
+from madminer.utils.various import weighted_quantile, sanitize_array
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +183,14 @@ def plot_distributions(
                 for nuisance_toy in nuisance_toys
             ]
         )  # Shape (n_toys, n_events)
-        logger.debug("Calculated nuisance toy factors with shape %s", nuisance_toy_factors.shape)
+        logger.debug(
+            "Calculated nuisance toy factors with shape %s and range %s - %s",
+            nuisance_toy_factors.shape,
+            np.min(nuisance_toy_factors),
+            np.max(nuisance_toy_factors),
+        )
+
+        nuisance_toy_factors = sanitize_array(nuisance_toy_factors, min_value=1.0e-2, max_value=100.0)
 
         # Normalize
         if normalize:

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -15,7 +15,7 @@ def plot_distributions(
     filename,
     observables=None,
     parameter_points=None,
-    nuisance_points=False,
+    nuisance_points=None,
     n_samples=10000,
     observable_labels=None,
     n_bins=50,
@@ -96,7 +96,8 @@ def plot_distributions(
     n_observables = len(observables)
 
     if observable_labels is None:
-        observable_labels = list(sa.observables.keys())[observables]
+        observable_labels = list(sa.observables.keys())
+        observable_labels = [observable_labels[obs] for obs in observables]
 
     # Get unweighted data for each hypothesis
     samples = []
@@ -144,9 +145,9 @@ def plot_distributions(
         # Plot
         plt.subplot(n_rows, n_cols, i + 1)
 
-        for x, lw, color, label in zip(samples, linewidths, colors, line_labels):
+        for x, lw, color, label, ls in zip(samples, linewidths, colors, line_labels, linestyles):
             plt.hist(
-                x[:, i], histtype="step", range=x_range, bins=n_bins, lw=lw, color=color, label=label, density=True
+                x[:, i], histtype="step", range=x_range, bins=n_bins, lw=lw, ls=ls, color=color, label=label, density=True
             )
 
         plt.legend()

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -19,6 +19,7 @@ def plot_distributions(
     observables=None,
     parameter_points=None,
     uncertainties="nuisance",
+    nuisance_parameters=None,
     normalize=False,
     observable_labels=None,
     n_bins=50,
@@ -51,6 +52,10 @@ def plot_distributions(
     uncertainties : {"nuisance", "none"}, optional
         Defines how uncertainty bands are drawn. With "nuisance", the variation in cross section from all nuisance
         parameters is added in quadrature. With "none", no error bands are drawn.
+
+    nuisance_parameters : None or list of int, optional
+        If uncertainties is "nuisance", this can restrict which nuisance parameters are used to draw the uncertainty
+        bands. Each entry of this list is the index of one nuisance parameter (same order as in the MadMiner file).
 
     normalize : bool, optional
         Whether the distribution is normalized to the total cross section. Default value: False.
@@ -177,6 +182,12 @@ def plot_distributions(
 
         nuisance_toys = np.random.normal(loc=0.0, scale=1.0, size=n_nuisance_params * n_toys)
         nuisance_toys = nuisance_toys.reshape(n_toys, n_nuisance_params)
+
+        # Restrict nuisance parameters
+        if nuisance_parameters is not None:
+            for i in range(n_nuisance_params):
+                if i not in nuisance_parameters:
+                    nuisance_toys[:,i] = 1.
 
         logger.debug("Drew %s toy values for nuisance parameters", n_toys * n_nuisance_params)
 

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -28,7 +28,7 @@ def plot_distributions(
     linewidths=1.5,
     alpha=0.4,
     n_events=None,
-    n_toys=10000,
+    n_toys=1000,
 ):
     """
     Plots one-dimensional histograms of observables in a MadMiner file for a given set of benchmarks.
@@ -79,10 +79,11 @@ def plot_distributions(
         alpha value for the uncertainty bands. Default value: 0.4.
 
     n_events : None or int, optional
-        If not None, sets the number of events from the MadMiner file that will be analyzed and plotted.
+        If not None, sets the number of events from the MadMiner file that will be analyzed and plotted. Default value:
+        None.
 
     n_toys : int, optional
-        Number of toy nuisance parameter vectors used to estimate the systematic uncertainties.
+        Number of toy nuisance parameter vectors used to estimate the systematic uncertainties. Default value: 1000.
 
     Returns
     -------

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os
 import numpy as np
 from matplotlib import pyplot as plt
 import matplotlib
 import logging
 
-from madminer.utils.various import create_missing_folders
+logger = logging.getLogger(__name__)
 
 
 def plot_2d_morphing_basis(

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -28,6 +28,7 @@ def plot_distributions(
     linewidths=1.5,
     alpha=0.4,
     n_events=None,
+    n_toys=10000,
 ):
     """
     Plots one-dimensional histograms of observables in a MadMiner file for a given set of benchmarks.
@@ -79,6 +80,9 @@ def plot_distributions(
 
     n_events : None or int, optional
         If not None, sets the number of events from the MadMiner file that will be analyzed and plotted.
+
+    n_toys : int, optional
+        Number of toy nuisance parameter vectors used to estimate the systematic uncertainties.
 
     Returns
     -------
@@ -163,7 +167,6 @@ def plot_distributions(
 
     if uncertainties == "nuisance":
         n_nuisance_params = sa.n_nuisance_parameters
-        n_toys = 1000
 
         logger.debug("Calculating effect of nuisance parameters")
 

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -8,7 +8,7 @@ import logging
 
 from madminer.sampling import SampleAugmenter
 from madminer.utils.analysis import mdot, get_theta_benchmark_matrix
-from madminer.morphing import calculate_nuisance_factors
+from madminer.morphing import NuisanceMorpher
 from madminer.utils.various import weighted_quantile, sanitize_array
 
 logger = logging.getLogger(__name__)
@@ -88,7 +88,10 @@ def plot_distributions(
     """
 
     # Load data
-    sa = SampleAugmenter(filename)
+    sa = SampleAugmenter(filename, include_nuisance_parameters=True)
+    morpher = NuisanceMorpher(
+        sa.nuisance_parameters, list(sa.benchmarks.keys()), reference_benchmark=sa.reference_benchmark
+    )
 
     # Default parameters
     if parameter_points is None:

--- a/madminer/plotting.py
+++ b/madminer/plotting.py
@@ -29,6 +29,7 @@ def plot_distributions(
     alpha=0.4,
     n_events=None,
     n_toys=1000,
+    n_cols=3,
 ):
     """
     Plots one-dimensional histograms of observables in a MadMiner file for a given set of benchmarks.
@@ -84,6 +85,9 @@ def plot_distributions(
 
     n_toys : int, optional
         Number of toy nuisance parameter vectors used to estimate the systematic uncertainties. Default value: 1000.
+
+    n_cols : int, optional
+        Number of columns in the plot.
 
     Returns
     -------
@@ -246,7 +250,6 @@ def plot_distributions(
     # Plot distributions
     logger.debug("Plotting distributions")
 
-    n_cols = 3
     n_rows = (n_observables + n_cols - 1) // n_cols
 
     fig = plt.figure(figsize=(4.0 * n_cols, 4.0 * n_rows))

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -1278,13 +1278,12 @@ class SampleAugmenter:
         squared_weight_sum_benchmarks = None
         n_observables = 0
 
-        for obs, weights, sampled_from_benchmark in madminer_event_loader(
+        for obs, weights in madminer_event_loader(
             self.madminer_filename,
             start=start_event,
             end=end_event,
             include_nuisance_parameters=include_nuisance_parameters,
             benchmark_is_nuisance=self.benchmark_is_nuisance,
-            include_sampling_information=True,
         ):
             # obs has shape (n_events, n_observables)
             # weights has shape (n_events, n_benchmarks_phys)
@@ -1418,8 +1417,8 @@ class SampleAugmenter:
                 # Loop over weighted events
                 cumulative_p = np.array([0.0])
 
-                for x_batch, weights_benchmarks_batch, sampled_from_benchmark_batch in madminer_event_loader(
-                    self.madminer_filename, start=start_event, end=end_event, include_sampling_information=True
+                for x_batch, weights_benchmarks_batch in madminer_event_loader(
+                    self.madminer_filename, start=start_event, end=end_event
                 ):
                     # Evaluate p(x | sampling theta)
                     weights_theta = mdot(sampling_theta_matrix, weights_benchmarks_batch)  # Shape (n_batch_size,)

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -477,9 +477,9 @@ class SampleAugmenter:
 
             logging.debug(
                 "Found physical score with shape %s, nuisance score with shape %s, combined shape %s",
-                t_xz_physics,
-                t_xz_nuisance,
-                t_xz,
+                t_xz_physics.shape,
+                t_xz_nuisance.shape,
+                t_xz.shape,
             )
         else:
             t_xz = t_xz_physics

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -279,13 +279,13 @@ class SampleAugmenter:
             self.n_samples,
             _,
             self.reference_benchmark,
-            self.nuisanca_parameters,
+            self.nuisance_parameters,
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=include_nuisance_parameters)
 
         self.n_parameters = len(self.parameters)
         self.n_benchmarks = len(self.benchmarks)
         self.n_benchmarks_phys = np.sum(np.logical_not(self.benchmark_is_nuisance))
-        self.n_nuisance_parameters = self.n_benchmarks - self.n_benchmarks_phys
+        self.n_nuisance_parameters = len(self.nuisance_parameters)
 
         logger.info("Found %s parameters", self.n_parameters)
         for key, values in six.iteritems(self.parameters):

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -279,6 +279,7 @@ class SampleAugmenter:
             self.n_samples,
             _,
             self.reference_benchmark,
+            self.nuisanca_parameters,
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=include_nuisance_parameters)
 
         self.n_parameters = len(self.parameters)

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -10,7 +10,9 @@ from madminer.utils.interfaces.madminer_hdf5 import save_preformatted_events_to_
 from madminer.utils.analysis import get_theta_value, get_theta_benchmark_matrix, get_dtheta_benchmark_matrix
 from madminer.utils.analysis import calculate_augmented_data, parse_theta, mdot
 from madminer.morphing import Morpher
-from madminer.utils.various import general_init, format_benchmark, create_missing_folders, shuffle, balance_thetas
+from madminer.utils.various import format_benchmark, create_missing_folders, shuffle, balance_thetas
+
+logger = logging.getLogger(__name__)
 
 
 def combine_and_shuffle(input_filenames, output_filename, k_factors=None, overwrite_existing_file=True, debug=False):
@@ -44,8 +46,6 @@ def combine_and_shuffle(input_filenames, output_filename, k_factors=None, overwr
         None
 
     """
-
-    logger = general_init(debug=debug)
 
     logger.debug("Combining and shuffling samples")
 
@@ -262,14 +262,11 @@ class SampleAugmenter:
     """
 
     def __init__(self, filename, disable_morphing=False, include_nuisance_parameters=True, debug=False):
-
-        self.logger = general_init(debug=debug)
-
         # Save setup
         self.include_nuisance_parameters = include_nuisance_parameters
         self.madminer_filename = filename
 
-        self.logger.info("Loading data from %s", filename)
+        logger.info("Loading data from %s", filename)
 
         # Load data
         (
@@ -289,9 +286,9 @@ class SampleAugmenter:
         self.n_benchmarks_phys = np.sum(np.logical_not(self.benchmark_is_nuisance))
         self.n_nuisance_parameters = self.n_benchmarks - self.n_benchmarks_phys
 
-        self.logger.info("Found %s parameters:", self.n_parameters)
+        logger.info("Found %s parameters:", self.n_parameters)
         for key, values in six.iteritems(self.parameters):
-            self.logger.info(
+            logger.info(
                 "   %s (LHA: %s %s, maximal power in squared ME: %s, range: %s)",
                 key,
                 values[0],
@@ -300,15 +297,15 @@ class SampleAugmenter:
                 values[3],
             )
 
-        self.logger.info("Found %s benchmarks, of which %s physical:", self.n_benchmarks, self.n_benchmarks_phys)
+        logger.info("Found %s benchmarks, of which %s physical:", self.n_benchmarks, self.n_benchmarks_phys)
         for (key, values), is_nuisance in zip(six.iteritems(self.benchmarks), self.benchmark_is_nuisance):
             if is_nuisance:
-                self.logger.info("   %s: nuisance parameter", key)
+                logger.info("   %s: nuisance parameter", key)
             else:
-                self.logger.info("   %s: %s", key, format_benchmark(values))
+                logger.info("   %s: %s", key, format_benchmark(values))
 
-        self.logger.info("Found %s observables: %s", len(self.observables), ", ".join(self.observables))
-        self.logger.info("Found %s events", self.n_samples)
+        logger.info("Found %s observables: %s", len(self.observables), ", ".join(self.observables))
+        logger.info("Found %s events", self.n_samples)
 
         # Morphing
         self.morpher = None
@@ -317,10 +314,10 @@ class SampleAugmenter:
             self.morpher.set_components(self.morphing_components)
             self.morpher.set_basis(self.benchmarks, morphing_matrix=self.morphing_matrix)
 
-            self.logger.info("Found morphing setup with %s components", len(self.morphing_components))
+            logger.info("Found morphing setup with %s components", len(self.morphing_components))
 
         else:
-            self.logger.info("Did not find morphing setup.")
+            logger.info("Did not find morphing setup.")
 
     def extract_samples_train_plain(
         self, theta, n_samples, folder, filename, test_split=0.5, switch_train_test_events=False
@@ -367,7 +364,7 @@ class SampleAugmenter:
 
         """
 
-        self.logger.info("Extracting plain training sample. Sampling according to %s", theta)
+        logger.info("Extracting plain training sample. Sampling according to %s", theta)
 
         create_missing_folders([folder])
 
@@ -458,7 +455,7 @@ class SampleAugmenter:
         """
 
         if log_message:
-            self.logger.info(
+            logger.info(
                 "Extracting training sample for local score regression. Sampling and score evaluation according to %s",
                 theta,
             )
@@ -495,7 +492,7 @@ class SampleAugmenter:
             t_xz_nuisance = augmented_data[1]
             t_xz = np.hstack([t_xz_physics, t_xz_nuisance])
 
-            self.logger.debug(
+            logger.debug(
                 "Found physical score with shape %s, nuisance score with shape %s, combined shape %s",
                 t_xz_physics.shape,
                 t_xz_nuisance.shape,
@@ -560,7 +557,7 @@ class SampleAugmenter:
 
         """
 
-        self.logger.info(
+        logger.info(
             "Extracting training sample for non-local score-based methods. Sampling and score evaluation according "
             "to %s",
             theta,
@@ -642,7 +639,7 @@ class SampleAugmenter:
 
         """
 
-        self.logger.info(
+        logger.info(
             "Extracting training sample for ratio-based methods. Numerator hypothesis: %s, denominator "
             "hypothesis: %s",
             theta0,
@@ -807,7 +804,7 @@ class SampleAugmenter:
 
         """
 
-        self.logger.info(
+        logger.info(
             "Extracting training sample for ratio-based methods. Numerator hypothesis: %s, denominator "
             "hypothesis: %s",
             theta0,
@@ -962,7 +959,7 @@ class SampleAugmenter:
         y[x_0.shape[0] :] = 1.0
 
         if n_additional_thetas > 0:
-            self.logger.info(
+            logger.info(
                 "Oversampling: created %s training samples from %s original unweighted events",
                 x.shape[0],
                 n_actual_samples,
@@ -1027,7 +1024,7 @@ class SampleAugmenter:
 
         """
 
-        self.logger.info("Extracting evaluation sample. Sampling according to %s", theta)
+        logger.info("Extracting evaluation sample. Sampling according to %s", theta)
 
         create_missing_folders([folder])
 
@@ -1079,7 +1076,7 @@ class SampleAugmenter:
 
         """
 
-        self.logger.info("Starting cross-section calculation")
+        logger.info("Starting cross-section calculation")
 
         # Total xsecs for benchmarks
         xsecs_benchmarks = None
@@ -1117,7 +1114,7 @@ class SampleAugmenter:
             all_xsecs.append(xsec_theta)
             all_xsec_uncertainties.append(rms_xsec_theta)
 
-            self.logger.debug("theta %s: xsec = (%s +/- %s) pb", theta, xsec_theta, rms_xsec_theta)
+            logger.debug("theta %s: xsec = (%s +/- %s) pb", theta, xsec_theta, rms_xsec_theta)
 
         # Return
         all_thetas = np.array(all_thetas)
@@ -1234,16 +1231,16 @@ class SampleAugmenter:
 
         """
 
-        self.logger.debug("Starting sample extraction")
+        logger.debug("Starting sample extraction")
 
         assert n_samples_per_theta > 0, "Requested {} samples per theta!".format(n_samples_per_theta)
 
         if augmented_data_definitions is None:
             augmented_data_definitions = []
 
-        self.logger.debug("Augmented data requested:")
+        logger.debug("Augmented data requested:")
         for augmented_data_definition in augmented_data_definitions:
-            self.logger.debug("  %s", augmented_data_definition)
+            logger.debug("  %s", augmented_data_definition)
 
         # Nuisance parameters?
         include_nuisance_parameters = self.include_nuisance_parameters and nuisance_score
@@ -1252,7 +1249,7 @@ class SampleAugmenter:
         if self.reference_benchmark is not None:
             i_ref_benchmark = list(self.benchmarks.keys()).index(self.reference_benchmark)
         elif include_nuisance_parameters:
-            self.logger.warning("No reference benchmark found. Using first benchmark.")
+            logger.warning("No reference benchmark found. Using first benchmark.")
 
         # Calculate total xsecs for benchmarks
         xsecs_benchmarks = None
@@ -1280,7 +1277,7 @@ class SampleAugmenter:
 
             n_observables = obs.shape[1]
 
-        self.logger.debug("Benchmark cross sections [pb]: %s", xsecs_benchmarks)
+        logger.debug("Benchmark cross sections [pb]: %s", xsecs_benchmarks)
 
         # Balance thetas
         theta_sets_types, theta_sets_values = balance_thetas(theta_sets_types, theta_sets_values)
@@ -1341,7 +1338,7 @@ class SampleAugmenter:
             theta_matrices = []
             theta_gradient_matrices = []
 
-            self.logger.debug("Drawing %s events for the following thetas:", n_samples)
+            logger.debug("Drawing %s events for the following thetas:", n_samples)
 
             for i_theta, (theta_type, theta_value) in enumerate(zip(theta_types, theta_values)):
                 theta = get_theta_value(theta_type, theta_value, self.benchmarks)
@@ -1355,7 +1352,7 @@ class SampleAugmenter:
                     get_dtheta_benchmark_matrix(theta_type, theta_value, self.benchmarks, self.morpher)
                 )
 
-                self.logger.debug(
+                logger.debug(
                     "  theta %s = %s%s", i_theta, theta[0, :], " (sampling)" if i_theta == sampling_theta_index else ""
                 )
 
@@ -1368,7 +1365,7 @@ class SampleAugmenter:
             ) ** 0.5
 
             if rms_xsec_sampling_theta > 0.1 * xsec_sampling_theta:
-                self.logger.warning(
+                logger.warning(
                     "Warning: large statistical uncertainty on the total cross section for theta = %s: "
                     "(%s +/- %s) pb",
                     thetas[sampling_theta_index][0],
@@ -1409,7 +1406,7 @@ class SampleAugmenter:
                     # Handle negative weights (should be rare)
                     n_negative_weights = np.sum(p_theta < 0.0)
                     if n_negative_weights > 0:
-                        self.logger.warning(
+                        logger.warning(
                             "%s negative weights (%s)", n_negative_weights, n_negative_weights / p_theta.size
                         )
                     p_theta[p_theta < 0.0] = 0.0
@@ -1455,11 +1452,11 @@ class SampleAugmenter:
                         break
 
                 # Cross-check cumulative probabilities at end
-                self.logger.debug("  Cumulative probability (should be close to 1): %s", cumulative_p[-1])
+                logger.debug("  Cumulative probability (should be close to 1): %s", cumulative_p[-1])
 
                 # Check that we got 'em all, otherwise repeat
                 if not np.all(samples_done):
-                    self.logger.debug(
+                    logger.debug(
                         "  After full pass through event files, {} / {} samples not found, u = {}".format(
                             np.sum(np.invert(samples_done)), samples_done.size, u[np.invert(samples_done)]
                         )
@@ -1482,15 +1479,15 @@ class SampleAugmenter:
 
         # Report effective number of samples
         if n_sets > 1:
-            self.logger.info(
+            logger.info(
                 "Effective number of samples: mean %s, with individual thetas ranging from %s to %s",
                 np.mean(all_effective_n_samples),
                 np.min(all_effective_n_samples),
                 np.max(all_effective_n_samples),
             )
-            self.logger.debug("Effective number of samples for all thetas: %s", all_effective_n_samples)
+            logger.debug("Effective number of samples for all thetas: %s", all_effective_n_samples)
         else:
-            self.logger.info("Effective number of samples: %s", all_effective_n_samples[0])
+            logger.info("Effective number of samples: %s", all_effective_n_samples[0])
 
         return all_x, all_augmented_data, all_thetas
 

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -1148,7 +1148,7 @@ class SampleAugmenter:
 
         weights : ndarray
             If theta is None and derivative is False, benchmark weights with shape
-            `(n_unweighted_samples, n_benchmarks)` in pb. If theta is not None and derivative is True, the gradient of
+            `(n_unweighted_samples, n_benchmarks_phys)` in pb. If theta is not None and derivative is True, the gradient of
             the weight for the given parameter with respect to theta with shape `(n_unweighted_samples, n_gradients)`
             in pb. Otherwise, weights for the given parameter theta with shape `(n_unweighted_samples,)` in pb.
 
@@ -1273,7 +1273,7 @@ class SampleAugmenter:
             include_sampling_information=True,
         ):
             # obs has shape (n_events, n_observables)
-            # weights has shape (n_events, n_benchmarks)
+            # weights has shape (n_events, n_benchmarks_phys)
             # sampled_from_benchmark has shape (n_events,)
 
             if xsecs_benchmarks is None:

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -285,7 +285,12 @@ class SampleAugmenter:
         self.n_parameters = len(self.parameters)
         self.n_benchmarks = len(self.benchmarks)
         self.n_benchmarks_phys = np.sum(np.logical_not(self.benchmark_is_nuisance))
-        self.n_nuisance_parameters = len(self.nuisance_parameters)
+
+        self.n_nuisance_parameters = 0
+        if self.nuisance_parameters is not None and include_nuisance_parameters:
+            self.n_nuisance_parameters = len(self.nuisance_parameters)
+        else:
+            self.nuisance_parameters = None
 
         logger.info("Found %s parameters", self.n_parameters)
         for key, values in six.iteritems(self.parameters):
@@ -1129,8 +1134,8 @@ class SampleAugmenter:
             theta_matrix = get_theta_benchmark_matrix(theta_type, theta_value, self.benchmarks, self.morpher)
 
             # Total xsec for this theta
-            xsec_theta = theta_matrix.dot(xsecs_benchmarks)
-            rms_xsec_theta = ((theta_matrix * theta_matrix).dot(squared_weight_sum_benchmarks)) ** 0.5
+            xsec_theta = mdot(theta_matrix, xsecs_benchmarks)
+            rms_xsec_theta = mdot(theta_matrix * theta_matrix, squared_weight_sum_benchmarks) ** 0.5
 
             all_thetas.append(theta)
             all_xsecs.append(xsec_theta)

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -267,6 +267,7 @@ class SampleAugmenter:
         self.n_parameters = len(self.parameters)
         self.n_benchmarks = len(self.benchmarks)
         self.n_benchmarks_phys = np.sum(np.logical_not(self.benchmark_is_nuisance))
+        self.n_nuisance_parameters = self.n_benchmarks - self.n_benchmarks_phys
 
         logging.info("Found %s parameters:", self.n_parameters)
         for key, values in six.iteritems(self.parameters):
@@ -1375,6 +1376,8 @@ class SampleAugmenter:
                     samples_augmented_data.append(np.zeros((n_samples, 1)))
                 elif definition[0] == "score":
                     samples_augmented_data.append(np.zeros((n_samples, self.n_parameters)))
+                elif definition[0] == "nuisance_score":
+                    samples_augmented_data.append(np.zeros((n_samples, self.n_nuisance_parameters)))
 
             largest_weight = 0.0
 

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -262,6 +262,7 @@ class SampleAugmenter:
             self.morphing_matrix,
             self.observables,
             self.n_samples,
+            _
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=include_nuisance_parameters)
 
         self.n_parameters = len(self.parameters)

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -304,7 +304,7 @@ class SampleAugmenter:
             else:
                 logger.debug("   %s: %s", key, format_benchmark(values))
 
-        logger.info("Found %s observables")
+        logger.info("Found %s observables", len(self.observables))
         for i, obs in enumerate(self.observables):
             logger.debug("  %2.2s %s", i, obs)
         logger.info("Found %s events", self.n_samples)

--- a/madminer/sampling.py
+++ b/madminer/sampling.py
@@ -262,7 +262,7 @@ class SampleAugmenter:
             self.morphing_matrix,
             self.observables,
             self.n_samples,
-            _
+            _,
         ) = load_madminer_settings(filename, include_nuisance_benchmarks=include_nuisance_parameters)
 
         self.n_parameters = len(self.parameters)
@@ -1423,7 +1423,9 @@ class SampleAugmenter:
                     # Information for nuisance parameters
                     if include_nuisance_parameters:
                         weights_nuisance_at_ref_benchmark = []
-                        for weight, sampled_from in zip(weights_benchmarks_batch[indices[found_now], :], sampled_from_benchmark[indices[found_now]]):
+                        for weight, sampled_from in zip(
+                            weights_benchmarks_batch[indices[found_now], :], sampled_from_benchmark[indices[found_now]]
+                        ):
                             weights_nuisance_at_ref_benchmark.append(
                                 weight[nuisance_filter] * weight[i_ref_benchmark] / weight[sampled_from]
                             )
@@ -1438,7 +1440,8 @@ class SampleAugmenter:
                             xsecs_benchmarks,
                             theta_matrices,
                             theta_gradient_matrices,
-                            weights_nuisance_ratios=weights_nuisance_at_ref_benchmark / weights_ref_benchmark[:,np.newaxis],
+                            weights_nuisance_ratios=weights_nuisance_at_ref_benchmark
+                            / weights_ref_benchmark[:, np.newaxis],
                             xsecs_nuisance_ratios=xsec_nuisance_at_ref_benchmark / xsec_ref_benchmark[np.newaxis],
                         )
                     else:

--- a/madminer/utils/analysis.py
+++ b/madminer/utils/analysis.py
@@ -107,6 +107,8 @@ def calculate_augmented_data(
             nuisance_score = np.log(weights_nuisance_ratios)  # Shape (n_samples, n_nuisance)
             nuisance_score -= np.log(xsecs_nuisance_ratios)[np.newaxis, :]  # Shape (n_samples, n_nuisance)
 
+            logging.debug("Nuisance score: shape %s, content %s", nuisance_score.shape, nuisance_score)
+
             augmented_data.append(nuisance_score)
 
         else:
@@ -182,7 +184,7 @@ def parse_theta(theta, n_samples):
 def mdot(matrix, benchmark_information):
     """ Calculates a product between a matrix with shape (a, n1) and a weight list with shape (?, n2) with n1 <= n2 """
 
-    _, n_benchmarks_matrix = matrix.shape
+    n_benchmarks_matrix = matrix.shape[-1]
     weights_benchmarks_T = benchmark_information.T
     n_benchmarks_in = weights_benchmarks_T.shape[0]
 

--- a/madminer/utils/analysis.py
+++ b/madminer/utils/analysis.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 import six
-import logging
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 def get_theta_value(theta_type, theta_value, benchmarks):
@@ -115,7 +117,7 @@ def calculate_augmented_data(
             nuisance_score = np.log(weight_ratio)  # Shape (n_samples, n_nuisance)
             nuisance_score -= np.log(xsec_ratio)[np.newaxis, :]  # Shape (n_samples, n_nuisance)
 
-            logging.debug("Nuisance score: shape %s, content %s", nuisance_score.shape, nuisance_score)
+            logger.debug("Nuisance score: shape %s, content %s", nuisance_score.shape, nuisance_score)
 
             augmented_data.append(nuisance_score)
 
@@ -176,7 +178,7 @@ def parse_theta(theta, n_samples):
         theta_values = np.array(theta_values).T
         n_samples_per_theta = int(round(n_samples / n_benchmarks, 0))
 
-        logging.debug(
+        logger.debug(
             "Total n_samples: %s, n_benchmarks: %s, n_samples_per_theta: %s",
             n_samples,
             n_benchmarks,

--- a/madminer/utils/analysis.py
+++ b/madminer/utils/analysis.py
@@ -66,8 +66,8 @@ def calculate_augmented_data(
     xsecs_benchmarks,
     theta_matrices,
     theta_gradient_matrices,
-    weights_nuisance_ratios=None,
-    xsecs_nuisance_ratios=None,
+    nuisance_filter=None,
+    i_ref_benchmark=None,
 ):
     """Extracts augmented data from benchmark weights"""
     augmented_data = []
@@ -104,8 +104,16 @@ def calculate_augmented_data(
             augmented_data.append(score)
 
         elif definition[0] == "nuisance_score":
-            nuisance_score = np.log(weights_nuisance_ratios)  # Shape (n_samples, n_nuisance)
-            nuisance_score -= np.log(xsecs_nuisance_ratios)[np.newaxis, :]  # Shape (n_samples, n_nuisance)
+            assert i_ref_benchmark is not None, "i_ref_benchmark cannot be None when nuisance scores are calculated"
+            assert nuisance_filter is not None, "nuisance_filter cannot be None when nuisance scores are calculated"
+
+            weight_ratio = (
+                weights_benchmarks[:, nuisance_filter] / (weights_benchmarks[:, i_ref_benchmark])[:, np.newaxis]
+            )
+            xsec_ratio = xsecs_benchmarks[nuisance_filter] / xsecs_benchmarks[i_ref_benchmark]
+
+            nuisance_score = np.log(weight_ratio)  # Shape (n_samples, n_nuisance)
+            nuisance_score -= np.log(xsec_ratio)[np.newaxis, :]  # Shape (n_samples, n_nuisance)
 
             logging.debug("Nuisance score: shape %s, content %s", nuisance_score.shape, nuisance_score)
 

--- a/madminer/utils/analysis.py
+++ b/madminer/utils/analysis.py
@@ -78,10 +78,10 @@ def calculate_augmented_data(
             i_num = definition[1]
             i_den = definition[2]
 
-            dsigma_num = _mdot(theta_matrices[i_num], weights_benchmarks)
-            sigma_num = _mdot(theta_matrices[i_num], xsecs_benchmarks)
-            dsigma_den = _mdot(theta_matrices[i_den], weights_benchmarks)
-            sigma_den = _mdot(theta_matrices[i_den], xsecs_benchmarks)
+            dsigma_num = mdot(theta_matrices[i_num], weights_benchmarks)
+            sigma_num = mdot(theta_matrices[i_num], xsecs_benchmarks)
+            dsigma_den = mdot(theta_matrices[i_den], weights_benchmarks)
+            sigma_den = mdot(theta_matrices[i_den], xsecs_benchmarks)
 
             ratio = (dsigma_num / sigma_num) / (dsigma_den / sigma_den)
             ratio = ratio.reshape((-1, 1))
@@ -91,11 +91,11 @@ def calculate_augmented_data(
         elif definition[0] == "score":
             i = definition[1]
 
-            gradient_dsigma = theta_gradient_matrices[i].dot(weights_benchmarks.T)  # (n_gradients, n_samples)
-            gradient_sigma = theta_gradient_matrices[i].dot(xsecs_benchmarks.T)  # (n_gradients,)
+            gradient_dsigma = mdot(theta_gradient_matrices[i], weights_benchmarks)  # (n_gradients, n_samples)
+            gradient_sigma = mdot(theta_gradient_matrices[i], xsecs_benchmarks)  # (n_gradients,)
 
-            dsigma = _mdot(theta_matrices[i], weights_benchmarks)  # (n_samples,)
-            sigma = _mdot(theta_matrices[i], xsecs_benchmarks)  # scalar
+            dsigma = mdot(theta_matrices[i], weights_benchmarks)  # (n_samples,)
+            sigma = mdot(theta_matrices[i], xsecs_benchmarks)  # scalar
 
             score = gradient_dsigma / dsigma  # (n_gradients, n_samples)
             score = score.T  # (n_samples, n_gradients)
@@ -179,9 +179,11 @@ def parse_theta(theta, n_samples):
     return theta_types, theta_values, n_samples_per_theta
 
 
-def _mdot(matrix, weights_benchmarks):
+def mdot(matrix, benchmark_information):
+    """ Calculates a product between a matrix with shape (a, n1) and a weight list with shape (?, n2) with n1 <= n2 """
+
     _, n_benchmarks_matrix = matrix.shape
-    weights_benchmarks_T = weights_benchmarks.T
+    weights_benchmarks_T = benchmark_information.T
     n_benchmarks_in = weights_benchmarks_T.shape[0]
 
     if n_benchmarks_matrix == n_benchmarks_in:

--- a/madminer/utils/analysis.py
+++ b/madminer/utils/analysis.py
@@ -61,7 +61,13 @@ def get_dtheta_benchmark_matrix(theta_type, theta_value, benchmarks, morpher=Non
 
 
 def calculate_augmented_data(
-    augmented_data_definitions, weights_benchmarks, xsecs_benchmarks, theta_matrices, theta_gradient_matrices
+    augmented_data_definitions,
+    weights_benchmarks,
+    xsecs_benchmarks,
+    theta_matrices,
+    theta_gradient_matrices,
+    weights_nuisance_ratios,
+    xsecs_nuisance_ratios,
 ):
     """Extracts augmented data from benchmark weights"""
     augmented_data = []
@@ -98,7 +104,10 @@ def calculate_augmented_data(
             augmented_data.append(score)
 
         elif definition[0] == "nuisance_score":
-            raise NotImplementedError
+            nuisance_score = np.log(weights_nuisance_ratios)  # Shape (n_samples, n_nuisance)
+            nuisance_score -= np.log(xsecs_nuisance_ratios)[np.newaxis, :]  # Shape (n_samples, n_nuisance)
+
+            augmented_data.append(nuisance_score)
 
         else:
             raise ValueError("Unknown augmented data type {}".format(definition[0]))

--- a/madminer/utils/analysis.py
+++ b/madminer/utils/analysis.py
@@ -54,7 +54,9 @@ def get_dtheta_benchmark_matrix(theta_type, theta_value, benchmarks, morpher=Non
         if morpher is None:
             raise RuntimeError("Cannot calculate score without morphing")
 
-        dtheta_matrix = morpher.calculate_morphing_weight_gradient(theta_value)  # Shape (n_parameters, n_benchmarks)
+        dtheta_matrix = morpher.calculate_morphing_weight_gradient(
+            theta_value
+        )  # Shape (n_parameters, n_benchmarks_phys)
 
     else:
         raise ValueError("Unknown theta {}".format(theta_type))
@@ -179,7 +181,7 @@ def parse_theta(theta, n_samples):
         n_samples_per_theta = int(round(n_samples / n_benchmarks, 0))
 
         logger.debug(
-            "Total n_samples: %s, n_benchmarks: %s, n_samples_per_theta: %s",
+            "Total n_samples: %s, n_benchmarks_phys: %s, n_samples_per_theta: %s",
             n_samples,
             n_benchmarks,
             n_samples_per_theta,

--- a/madminer/utils/analysis.py
+++ b/madminer/utils/analysis.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 import six
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def get_theta_value(theta_type, theta_value, benchmarks):

--- a/madminer/utils/analysis.py
+++ b/madminer/utils/analysis.py
@@ -66,8 +66,8 @@ def calculate_augmented_data(
     xsecs_benchmarks,
     theta_matrices,
     theta_gradient_matrices,
-    weights_nuisance_ratios,
-    xsecs_nuisance_ratios,
+    weights_nuisance_ratios=None,
+    xsecs_nuisance_ratios=None,
 ):
     """Extracts augmented data from benchmark weights"""
     augmented_data = []

--- a/madminer/utils/interfaces/delphes.py
+++ b/madminer/utils/interfaces/delphes.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-import logging
+from madminer.utils.various import general_init, call_command
 
-from madminer.utils.various import call_command
+logger = general_init(debug=None)
 
 
 def run_delphes(
@@ -22,7 +22,7 @@ def run_delphes(
     filename, extension = os.path.splitext(hepmc_sample_filename)
     to_delete = None
     if extension == ".gz":
-        logging.debug("Unzipping %s", hepmc_sample_filename)
+        logger.debug("Unzipping %s", hepmc_sample_filename)
         if not os.path.exists(filename):
             call_command("gunzip -k {}".format(hepmc_sample_filename))
         if delete_unzipped_file:
@@ -67,7 +67,7 @@ def run_delphes(
 
     # Delete untarred file
     if to_delete is not None:
-        logging.debug("Deleting %s", to_delete)
+        logger.debug("Deleting %s", to_delete)
         os.remove(to_delete)
 
     return delphes_sample_filename

--- a/madminer/utils/interfaces/delphes.py
+++ b/madminer/utils/interfaces/delphes.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import logging
 
-from madminer.various.utils import call_command
+from madminer.utils.various import call_command
 
 logger = logging.getLogger(__name__)
 

--- a/madminer/utils/interfaces/delphes.py
+++ b/madminer/utils/interfaces/delphes.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-from madminer.utils.various import general_init, call_command
+import logging
 
-logger = general_init(debug=None)
+from madminer.various.utils import call_command
+
+logger = logging.getLogger(__name__)
 
 
 def run_delphes(

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -4,11 +4,11 @@ import six
 import numpy as np
 from collections import OrderedDict
 import uproot
-from madminer.utils.particle import MadMinerParticle
-import logging
 import os
+from madminer.utils.particle import MadMinerParticle
+from madminer.utils.various import math_commands, general_init
 
-from madminer.utils.various import math_commands
+logger = general_init(debug=None)
 
 
 def parse_delphes_root_file(
@@ -32,8 +32,8 @@ def parse_delphes_root_file(
 ):
     """ Extracts observables and weights from a Delphes ROOT file """
 
-    logging.debug("Parsing Delphes file %s", delphes_sample_file)
-    logging.debug("Expected weight labels: %s", weight_labels)
+    logger.debug("Parsing Delphes file %s", delphes_sample_file)
+    logger.debug("Expected weight labels: %s", weight_labels)
 
     # Delphes ROOT file
     root_file = uproot.open(delphes_sample_file)
@@ -47,7 +47,7 @@ def parse_delphes_root_file(
     n_weights = len(weights[0])
     n_events = len(weights)
 
-    logging.debug("Found %s events, %s weights", n_events, n_weights)
+    logger.debug("Found %s events, %s weights", n_events, n_weights)
 
     assert n_weights == len(weight_labels)
 
@@ -142,7 +142,7 @@ def parse_delphes_root_file(
         values_this_observable = np.array(values_this_observable, dtype=np.float)
         observable_values[obs_name] = values_this_observable
 
-        logging.debug("  First 10 values for observable %s:\n%s", obs_name, values_this_observable[:10])
+        logger.debug("  First 10 values for observable %s:\n%s", obs_name, values_this_observable[:10])
 
     # Cuts
     cut_values = []
@@ -174,7 +174,7 @@ def parse_delphes_root_file(
             n_pass = np.sum(this_filter)
             n_fail = np.sum(np.invert(this_filter))
 
-            logging.debug("  %s / %s events pass required observable %s", n_pass, n_pass + n_fail, obs_name)
+            logger.debug("  %s / %s events pass required observable %s", n_pass, n_pass + n_fail, obs_name)
 
             if combined_filter is None:
                 combined_filter = this_filter
@@ -186,7 +186,7 @@ def parse_delphes_root_file(
         n_pass = np.sum(values_this_cut)
         n_fail = np.sum(np.invert(values_this_cut))
 
-        logging.debug("  %s / %s events pass cut %s", n_pass, n_pass + n_fail, cut)
+        logger.debug("  %s / %s events pass cut %s", n_pass, n_pass + n_fail, cut)
 
         if combined_filter is None:
             combined_filteparse_delphes_root_filer = values_this_cut
@@ -199,11 +199,11 @@ def parse_delphes_root_file(
         n_fail = np.sum(np.invert(combined_filter))
 
         if n_pass == 0:
-            logging.warning("  No observations remainining!")
+            logger.warning("  No observations remainining!")
 
             return None, None, combined_filter
 
-        logging.info("  %s / %s events pass everything", n_pass, n_pass + n_fail)
+        logger.info("  %s / %s events pass everything", n_pass, n_pass + n_fail)
 
         for obs_name in observable_values:
             observable_values[obs_name] = observable_values[obs_name][combined_filter]
@@ -217,7 +217,7 @@ def parse_delphes_root_file(
 
     # Delete Delphes file
     if delete_delphes_sample_file:
-        logging.debug("  Deleting %s", delphes_sample_file)
+        logger.debug("  Deleting %s", delphes_sample_file)
         os.remove(delphes_sample_file)
 
     return observable_values, weights_dict, combined_filter
@@ -336,7 +336,7 @@ def _get_particles_leptons(tree, pt_min_e, eta_max_e, pt_min_mu, eta_max_mu):
                     continue
 
             else:
-                logging.warning("Delphes ROOT file has lepton with PDG ID %s, ignoring it", pdgid)
+                logger.warning("Delphes ROOT file has lepton with PDG ID %s, ignoring it", pdgid)
                 continue
 
             particle = MadMinerParticle()

--- a/madminer/utils/interfaces/delphes_root.py
+++ b/madminer/utils/interfaces/delphes_root.py
@@ -5,10 +5,12 @@ import numpy as np
 from collections import OrderedDict
 import uproot
 import os
-from madminer.utils.particle import MadMinerParticle
-from madminer.utils.various import math_commands, general_init
+import logging
 
-logger = general_init(debug=None)
+from madminer.utils.particle import MadMinerParticle
+from madminer.utils.various import math_commands
+
+logger = logging.getLogger(__name__)
 
 
 def parse_delphes_root_file(

--- a/madminer/utils/interfaces/hepmc.py
+++ b/madminer/utils/interfaces/hepmc.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 from io import open
-from madminer.utils.various import call_command, general_init
+import logging
+from madminer.utils.various import call_command
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def extract_weight_order(filename, default_weight_label=None):

--- a/madminer/utils/interfaces/hepmc.py
+++ b/madminer/utils/interfaces/hepmc.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import os
 from io import open
+from madminer.utils.various import call_command, general_init
 
-from madminer.utils.various import call_command
+logger = general_init(debug=None)
 
 
 def extract_weight_order(filename, default_weight_label=None):
@@ -22,7 +22,7 @@ def extract_weight_order(filename, default_weight_label=None):
             if len(terms) == 0 or terms[0] != "N":
                 continue
 
-            logging.debug("Parsing HepMC line: %s", line)
+            logger.debug("Parsing HepMC line: %s", line)
 
             n_benchmarks = int(terms[1])
             assert len(terms) == n_benchmarks + 2
@@ -37,11 +37,11 @@ def extract_weight_order(filename, default_weight_label=None):
                 else:
                     weight_labels.append(default_weight_label)
 
-            logging.debug("Found weight labels in HepMC file: %s", weight_labels)
+            logger.debug("Found weight labels in HepMC file: %s", weight_labels)
 
             return weight_labels
 
     # Default result (no reweighting, background scenario)
-    logging.debug("Did not find weight labels in HepMC file")
+    logger.debug("Did not find weight labels in HepMC file")
 
     return [default_weight_label]

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -110,9 +110,13 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
             call_command("gunzip -k {}".format(filename))
         filename = new_filename
 
+    # In some cases, the LHE file can contain non-ascii characters
+    with open(filename, "r") as file:
+        lhe_content = file.read()
+    lhe_content.encode("ascii", errors="ignore").decode()
+
     # Parse XML tree
-    tree = ET.parse(filename)
-    root = tree.getroot()
+    root = ET.fromstring(lhe_content)
 
     # Find weight groups
     try:

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -110,11 +110,15 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
             call_command("gunzip -k {}".format(filename))
         filename = new_filename
 
-    # In some cases, the LHE file can contain non-ascii characters
+    # In some cases, the LHE comments can contain bad characters
     with open(filename, "r") as file:
         lhe_content = file.read()
-    lhe_content.replace("\a", r"\a")
-    # TODO: replace with better solution: avoid run_card messing up \a and \a in the first place
+    lhe_lines = lhe_content.split("\n")
+    for i, line in enumerate(lhe_lines):
+        comment_pos = line.find("#")
+        if comment_pos >= 0:
+            lhe_lines[i] = line[:comment_pos]
+    lhe_content = "\n".join(lhe_lines)
 
     # Parse XML tree
     root = ET.fromstring(lhe_content)

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-import six
 
+import six
 import numpy as np
 from collections import OrderedDict
 import skhep.math
 import os
+import logging
 
-from madminer.utils.various import call_command, general_init
+from madminer.utils.various import call_command
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def extract_weights_from_lhe_file(filename, sampling_benchmark, is_background, rescale_factor=1.0):

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -87,7 +87,7 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
     systematics_scales = []
     for key, value in six.iteritems(systematics):
         if key in ["mur", "muf", "mu"]:
-            scale_factors = key.split(",")
+            scale_factors = value.split(",")
             scale_factors = [float(sf) for sf in scale_factors]
 
             if len(scale_factors) == 0:
@@ -101,7 +101,7 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
             systematics_scales.append(None)
 
     # Nuisance parameters (output)
-    nuisance_params = OrderedDict
+    nuisance_params = OrderedDict()
 
     # Untar event file
     new_filename, extension = os.path.splitext(filename)
@@ -116,7 +116,7 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
 
     # Find weight groups
     try:
-        weight_groups = root.findall("header")[0].findall("initrwgtx")[0].findall("weightgroup")
+        weight_groups = root.findall("header")[0].findall("initrwgt")[0].findall("weightgroup")
     except KeyError as e:
         raise RuntimeError("Could not find weight groups in LHE file!\n%s", e)
 
@@ -127,11 +127,11 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
     systematics_scale_done = []
     for val in systematics_scales:
         if val is None:
-            systematics_scale_done.append((True, True))
+            systematics_scale_done.append([True, True])
         elif len(val) == 1:
-            systematics_scale_done.append((False, True))
+            systematics_scale_done.append([False, True])
         else:
-            systematics_scale_done.append((False, False))
+            systematics_scale_done.append([False, False])
 
     systematics_pdf_done = False
 
@@ -178,9 +178,14 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
                                 and approx_equal(weight_mur, syst_scales[k])
                                 and approx_equal(weight_muf, 1.0)
                             ):
-                                benchmarks = nuisance_params.get(syst_name, (None, None))
+                                try:
+                                    benchmarks = nuisance_params[syst_name]
+                                except KeyError:
+                                    benchmarks = [None, None]
+
                                 benchmarks[k] = weight_id
                                 nuisance_params[syst_name] = benchmarks
+
                                 systematics_scale_done[i][k] = True
                                 break
 
@@ -191,9 +196,14 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
                                 and approx_equal(weight_mur, 1.0)
                                 and approx_equal(weight_muf, syst_scales[k])
                             ):
-                                benchmarks = nuisance_params.get(syst_name, (None, None))
+                                try:
+                                    benchmarks = nuisance_params[syst_name]
+                                except KeyError:
+                                    benchmarks = [None, None]
+
                                 benchmarks[k] = weight_id
                                 nuisance_params[syst_name] = benchmarks
+
                                 systematics_scale_done[i][k] = True
                                 break
 
@@ -204,9 +214,14 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
                                 and approx_equal(weight_mur, syst_scales[k])
                                 and approx_equal(weight_muf, syst_scales[k])
                             ):
-                                benchmarks = nuisance_params.get(syst_name, (None, None))
+                                try:
+                                    benchmarks = nuisance_params[syst_name]
+                                except KeyError:
+                                    benchmarks = [None, None]
+
                                 benchmarks[k] = weight_id
                                 nuisance_params[syst_name] = benchmarks
+
                                 systematics_scale_done[i][k] = True
                                 break
 

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -113,7 +113,8 @@ def extract_nuisance_parameters_from_lhe_file(filename, systematics):
     # In some cases, the LHE file can contain non-ascii characters
     with open(filename, "r") as file:
         lhe_content = file.read()
-    lhe_content.encode("ascii", errors="ignore").decode()
+    lhe_content.replace("\a", r"\a")
+    # TODO: replace with better solution: avoid run_card messing up \a and \a in the first place
 
     # Parse XML tree
     root = ET.fromstring(lhe_content)

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -5,9 +5,10 @@ import numpy as np
 from collections import OrderedDict
 import skhep.math
 import os
-import logging
 
-from madminer.utils.various import call_command
+from madminer.utils.various import call_command, general_init
+
+logger = general_init(debug=None)
 
 
 def extract_weights_from_lhe_file(filename, sampling_benchmark, is_background, rescale_factor=1.0):

--- a/madminer/utils/interfaces/lhe.py
+++ b/madminer/utils/interfaces/lhe.py
@@ -6,8 +6,9 @@ from collections import OrderedDict
 import skhep.math
 import os
 import logging
+import xml.etree.ElementTree as ET
 
-from madminer.utils.various import call_command
+from madminer.utils.various import call_command, approx_equal
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 def extract_weights_from_lhe_file(filename, sampling_benchmark, is_background, rescale_factor=1.0):
     """ Extracts weights from a LHE file and returns them as a dict with entries benchmark_name:values """
 
-    # Untar Event file
+    # Untar event file
     new_filename, extension = os.path.splitext(filename)
     if extension == ".gz":
         if not os.path.exists(new_filename):
@@ -79,10 +80,168 @@ def extract_weights_from_lhe_file(filename, sampling_benchmark, is_background, r
     return weights
 
 
+def extract_nuisance_parameters_from_lhe_file(filename, systematics):
+    """ Extracts the definition of nuisance parameters from the LHE file """
+
+    # Parse scale factors from strings in systematics
+    systematics_scales = []
+    for key, value in six.iteritems(systematics):
+        if key in ["mur", "muf", "mu"]:
+            scale_factors = key.split(",")
+            scale_factors = [float(sf) for sf in scale_factors]
+
+            if len(scale_factors) == 0:
+                raise RuntimeError("Cannot parse scale factor string %s", value)
+            elif len(scale_factors) == 1:
+                scale_factors = (scale_factors[0],)
+            else:
+                scale_factors = (scale_factors[-1], scale_factors[0])
+            systematics_scales.append(scale_factors)
+        else:
+            systematics_scales.append(None)
+
+    # Nuisance parameters (output)
+    nuisance_params = OrderedDict
+
+    # Untar event file
+    new_filename, extension = os.path.splitext(filename)
+    if extension == ".gz":
+        if not os.path.exists(new_filename):
+            call_command("gunzip -k {}".format(filename))
+        filename = new_filename
+
+    # Parse XML tree
+    tree = ET.parse(filename)
+    root = tree.getroot()
+
+    # Find weight groups
+    try:
+        weight_groups = root.findall("header")[0].findall("initrwgtx")[0].findall("weightgroup")
+    except KeyError as e:
+        raise RuntimeError("Could not find weight groups in LHE file!\n%s", e)
+
+    if len(weight_groups) == 0:
+        raise RuntimeError("Zero weight groups in LHE file!")
+
+    # What have we already found?
+    systematics_scale_done = []
+    for val in systematics_scales:
+        if val is None:
+            systematics_scale_done.append((True, True))
+        elif len(val) == 1:
+            systematics_scale_done.append((False, True))
+        else:
+            systematics_scale_done.append((False, False))
+
+    systematics_pdf_done = False
+
+    # Loop over weight groups and weights and identify benchmarks
+    for wg in weight_groups:
+        try:
+            wg_name = wg.attrib["name"]
+        except KeyError:
+            logging.warning("Weight group does not have name attribute")
+            continue
+
+        if "mg_reweighting" in wg_name.lower():  # Physics reweighting
+            continue
+
+        elif (
+            "mu" in systematics or "muf" in systematics or "mur" in systematics
+        ) and "scale variation" in wg_name.lower():  # Found scale variation weight group
+            weights = wg.findall("weight")
+
+            for weight in weights:
+                try:
+                    weight_id = str(weight.attrib["id"])
+                    weight_muf = float(weight.attrib["MUF"])
+                    weight_mur = float(weight.attrib["MUR"])
+                except KeyError:
+                    logging.warning("Scale variation weight does not have all expected attributes")
+                    continue
+
+                # Let's skip the entries with a varied dynamical scale for now
+                try:
+                    weight_dynscale = int(weight.attrib["dynscale"])
+                    continue
+                except KeyError:
+                    pass
+
+                # Matching time!
+                for i, (syst_name, syst_scales, syst_done) in enumerate(
+                    zip(systematics.keys(), systematics_scales, systematics_scale_done)
+                ):
+                    if syst_name == "mur":
+                        for k in [0, 1]:
+                            if (
+                                not syst_done[k]
+                                and approx_equal(weight_mur, syst_scales[k])
+                                and approx_equal(weight_muf, 1.0)
+                            ):
+                                benchmarks = nuisance_params.get(syst_name, (None, None))
+                                benchmarks[k] = weight_id
+                                nuisance_params[syst_name] = benchmarks
+                                systematics_scale_done[i][k] = True
+                                break
+
+                    if syst_name == "muf":
+                        for k in [0, 1]:
+                            if (
+                                not syst_done[k]
+                                and approx_equal(weight_mur, 1.0)
+                                and approx_equal(weight_muf, syst_scales[k])
+                            ):
+                                benchmarks = nuisance_params.get(syst_name, (None, None))
+                                benchmarks[k] = weight_id
+                                nuisance_params[syst_name] = benchmarks
+                                systematics_scale_done[i][k] = True
+                                break
+
+                    if syst_name == "mu":
+                        for k in [0, 1]:
+                            if (
+                                not syst_done[k]
+                                and approx_equal(weight_mur, syst_scales[k])
+                                and approx_equal(weight_muf, syst_scales[k])
+                            ):
+                                benchmarks = nuisance_params.get(syst_name, (None, None))
+                                benchmarks[k] = weight_id
+                                nuisance_params[syst_name] = benchmarks
+                                systematics_scale_done[i][k] = True
+                                break
+
+        elif "pdf" in systematics and systematics["pdf"].lower() in wg_name.lower():  # PDF reweighting
+            weights = wg.findall("weight")
+
+            for i, weight in enumerate(weights):
+                try:
+                    weight_id = str(weight.attrib["id"])
+                    weight_pdf = int(weight.attrib["PDF"])
+                except KeyError:
+                    logging.warning("Scale variation weight does not have all expected attributes")
+                    continue
+
+                # Add every PDF Hessian direction to nuisance parameters
+                nuisance_params["pdf_{}".format(i)] = (weight_id, None)
+
+                systematics_pdf_done = True
+
+    # Check that everything was found
+    if "pdf" in systematics.keys() and not systematics_pdf_done:
+        logging.warning("Did not find benchmarks representing PDF uncertainties in LHE file!")
+
+    for syst_name, (done1, done2) in zip(systematics.keys(), systematics_scale_done):
+        if not (done1 and done2):
+            logging.warning(
+                "Did not find benchmarks representing scale variation uncertainty %s in LHE file!", syst_name
+            )
+
+    return nuisance_params
+
+
 def extract_observables_from_lhe_file(
     filename, sampling_benchmark, is_background, rescale_factor, observables, benchmark_names
 ):
-
     """ Extracts observables and weights from a LHE file """
 
     # Untar Event file

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -327,7 +327,7 @@ def save_preformatted_events_to_madminer_file(
         f.create_dataset("samples/observations", data=observations)
 
 
-def save_nuisance_benchmarks_to_madminer_file(filename, weight_names, sort=True, copy_from=None):
+def save_nuisance_benchmarks_to_madminer_file(filename, weight_names, reference_benchmark=None, sort=True, copy_from=None):
     """ Saves the names of nuisance-defined benchmarks in an HDF5 file """
 
     # Copy file
@@ -382,9 +382,13 @@ def save_nuisance_benchmarks_to_madminer_file(filename, weight_names, sort=True,
         benchmark_is_nuisance = np.array(
             [1 if is_nuisance else 0 for is_nuisance in benchmark_is_nuisance], dtype=np.int
         )
+        benchmark_is_reference = np.array(
+            [1 if bname == reference_benchmark else 0 for bname in benchmark_names], dtype=np.int
+        )
 
         logging.debug("Combined benchmark names: %s", benchmark_names)
         logging.debug("Combined is_nuisance: %s", benchmark_is_nuisance)
+        logging.debug("Combined is_reference: %s", benchmark_is_reference)
 
         # Make room for saving all this glorious data
         del f["benchmarks"]
@@ -393,6 +397,7 @@ def save_nuisance_benchmarks_to_madminer_file(filename, weight_names, sort=True,
         f.create_dataset("benchmarks/names", (n_benchmarks,), dtype="S256", data=benchmark_names_ascii)
         f.create_dataset("benchmarks/values", data=benchmark_values)
         f.create_dataset("benchmarks/is_nuisance", data=benchmark_is_nuisance)
+        f.create_dataset("benchmarks/is_reference", data=benchmark_is_reference)
 
 
 def save_events_to_madminer_file(

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -215,8 +215,9 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             nuisance_parameter_names = _decode(nuisance_parameter_names)
             nusiance_parameter_benchmarks_pos = _decode(nusiance_parameter_benchmarks_pos)
             nusiance_parameter_benchmarks_neg = _decode(nusiance_parameter_benchmarks_neg)
-            nusiance_parameter_benchmarks_neg = [None if val == "" else val for val in nusiance_parameter_benchmarks_neg]
-
+            nusiance_parameter_benchmarks_neg = [
+                None if val == "" else val for val in nusiance_parameter_benchmarks_neg
+            ]
 
             nuisance_parameters = OrderedDict(
                 zip(nuisance_parameter_names, zip(nusiance_parameter_benchmarks_pos, nusiance_parameter_benchmarks_neg))

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -220,7 +220,8 @@ def madminer_event_loader(
             try:
                 sampled_from = f["samples/sampled_from_benchmark"]
             except KeyError:
-                raise RuntimeError("No sampling information stored in file {}".format(filename))
+                logging.warning("No sampling information stored in file {}".format(filename))
+                sampled_from = None
 
         # Preparations
         n_samples = observations.shape[0]
@@ -246,7 +247,8 @@ def madminer_event_loader(
             else:
                 this_weights = np.array(weights[current:this_end, benchmark_filter])
             if include_sampling_information:
-                this_sampled_from = np.array(sampled_from[current:this_end])
+                this_sampled_from = None if sampled_from is None else np.array(sampled_from[current:this_end])
+
                 yield (this_observations, this_weights, this_sampled_from)
             else:
                 yield (this_observations, this_weights)

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -194,17 +194,6 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             n_samples = 0
 
         # Systematics setup
-
-        # # Prepare and store systematics setup
-        # if systematics is not None:
-        #     systematics_names = [key for key in systematics]
-        #     n_systematics = len(systematics_names)
-        #     systematics_names_ascii = _encode(systematics_names)
-        #     systematics_values = _encode([systematics[key] for key in systematics_names])
-        #
-        #     f.create_dataset("systematics/names", (n_systematics,), dtype="S256", data=systematics_names_ascii)
-        #     f.create_dataset("systematics/values", (n_systematics,), dtype="S256", data=systematics_values)
-
         try:
             systematics_names = f["systematics/names"][()]
             systematics_values = f["systematics/values"][()]
@@ -217,6 +206,23 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
         except KeyError:
             systematics = None
 
+        # Nuisance parameters
+        try:
+            nuisance_parameter_names = f["nuisance_parameters/names"][()]
+            nusiance_parameter_benchmarks_pos = f["nuisance_parameters/benchmark_positive"][()]
+            nusiance_parameter_benchmarks_neg = f["nuisance_parameters/benchmark_negative"][()]
+
+            nuisance_parameter_names = _decode(nuisance_parameter_names)
+            nusiance_parameter_benchmarks_pos = _decode(nusiance_parameter_benchmarks_pos)
+            nusiance_parameter_benchmarks_neg = _decode(nusiance_parameter_benchmarks_neg)
+
+            nuisance_parameters = OrderedDict(
+                zip(nuisance_parameter_names, zip(nusiance_parameter_benchmarks_pos, nusiance_parameter_benchmarks_neg))
+            )
+
+        except KeyError:
+            nuisance_parameters = None
+
         return (
             parameters,
             benchmarks,
@@ -227,6 +233,7 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             n_samples,
             systematics,
             reference_benchmark,
+            nuisance_parameters,
         )
 
 

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -249,6 +249,11 @@ def madminer_event_loader(
             if include_sampling_information:
                 this_sampled_from = None if sampled_from is None else np.array(sampled_from[current:this_end])
 
+                # As a temporary solution, here's a hack:
+                # TODO: remove this!
+                if this_sampled_from is None:
+                    this_sampled_from = np.array([0 for _ in this_observations])
+
                 yield (this_observations, this_weights, this_sampled_from)
             else:
                 yield (this_observations, this_weights)

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -177,6 +177,12 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
         except KeyError:
             n_samples = 0
 
+        # Systematics setup
+        try:
+            systematics_arguments = f["systematics/arguments"][0].decode("ascii")
+        except KeyError:
+            systematics_arguments = None
+
         return (
             parameters,
             benchmarks,
@@ -185,6 +191,7 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             morphing_matrix,
             observables,
             n_samples,
+            systematics_arguments
         )
 
 

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -191,7 +191,7 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             morphing_matrix,
             observables,
             n_samples,
-            systematics_arguments
+            systematics_arguments,
         )
 
 

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -207,7 +207,7 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
 
         try:
             systematics_names = f["systematics/names"][()]
-            systematics_values = f["systematics/names"][()]
+            systematics_values = f["systematics/values"][()]
 
             systematics_names = _decode(systematics_names)
             systematics_values = _decode(systematics_values)

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -215,6 +215,8 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             nuisance_parameter_names = _decode(nuisance_parameter_names)
             nusiance_parameter_benchmarks_pos = _decode(nusiance_parameter_benchmarks_pos)
             nusiance_parameter_benchmarks_neg = _decode(nusiance_parameter_benchmarks_neg)
+            nusiance_parameter_benchmarks_neg = [None if val == "" else val for val in nusiance_parameter_benchmarks_neg]
+
 
             nuisance_parameters = OrderedDict(
                 zip(nuisance_parameter_names, zip(nusiance_parameter_benchmarks_pos, nusiance_parameter_benchmarks_neg))

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -241,12 +241,7 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
 
 
 def madminer_event_loader(
-    filename,
-    start=0,
-    end=None,
-    batch_size=100000,
-    include_nuisance_parameters=True,
-    benchmark_is_nuisance=None,
+    filename, start=0, end=None, batch_size=100000, include_nuisance_parameters=True, benchmark_is_nuisance=None
 ):
     # Nuisance parameter filtering
     if not include_nuisance_parameters:
@@ -477,12 +472,7 @@ def save_nuisance_setup_to_madminer_file(
 
 
 def save_events_to_madminer_file(
-    filename,
-    observables,
-    observations,
-    weights,
-    copy_from=None,
-    overwrite_existing_samples=True,
+    filename, observables, observations, weights, copy_from=None, overwrite_existing_samples=True
 ):
     if copy_from is not None:
         try:

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -129,6 +129,15 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             logging.info("HDF5 file does not contain is_nuisance field. Assuming is_nuisance=False for all benchmarks.")
             benchmark_is_nuisance = [False for _ in benchmark_names]
 
+        reference_benchmark = None
+        try:
+            benchmark_is_reference = f["benchmarks/is_reference"][()]
+            for is_reference, bname in zip(benchmark_is_reference, benchmark_names):
+                if is_reference:
+                    reference_benchmark = bname
+        except KeyError:
+            logging.info("HDF5 file does not contain is_reference field.")
+
         benchmark_names = [bname.decode("ascii") for bname in benchmark_names]
 
         benchmarks = OrderedDict()
@@ -192,6 +201,7 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             observables,
             n_samples,
             systematics_arguments,
+            reference_benchmark,
         )
 
 

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -131,6 +131,8 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
             logger.info("HDF5 file does not contain is_nuisance field. Assuming is_nuisance=False for all benchmarks.")
             benchmark_is_nuisance = [False for _ in benchmark_names]
 
+        benchmark_names = [bname.decode("ascii") for bname in benchmark_names]
+
         reference_benchmark = None
         try:
             benchmark_is_reference = f["benchmarks/is_reference"][()]
@@ -139,8 +141,6 @@ def load_madminer_settings(filename, include_nuisance_benchmarks=False):
                     reference_benchmark = bname
         except KeyError:
             logger.info("HDF5 file does not contain is_reference field.")
-
-        benchmark_names = [bname.decode("ascii") for bname in benchmark_names]
 
         benchmarks = OrderedDict()
 

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -217,11 +217,12 @@ def madminer_event_loader(
     # Nuisance parameter filtering
     if not include_nuisance_parameters:
         if benchmark_is_nuisance is None:
-            raise ValueError(
-                "MadMiner event loader requires include_nuisance_parameters=True or benchmark_is_nuisance to be set."
+            logging.warning(
+                "include_nuisance_parameters=False without benchmark_is_nuisance information. Returning all weights."
             )
-
-        benchmark_filter = np.logical_not(np.array(benchmark_is_nuisance, dtype=np.bool))
+            include_nuisance_parameters = True
+        else:
+            benchmark_filter = np.logical_not(np.array(benchmark_is_nuisance, dtype=np.bool))
 
     with h5py.File(filename, "r") as f:
 

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -268,7 +268,7 @@ def madminer_event_loader(
             current += batch_size
 
 
-def load_benchmarks_from_madminer_file(filename):
+def load_benchmarks_from_madminer_file(filename, include_nuisance_benchmarks=False):
     with h5py.File(filename, "r") as f:
 
         # Benchmarks
@@ -280,6 +280,21 @@ def load_benchmarks_from_madminer_file(filename):
 
         except KeyError:
             raise IOError("Cannot read benchmarks from HDF5 file")
+
+        if not include_nuisance_benchmarks:
+            try:
+                benchmark_is_nuisance = f["benchmarks/is_nuisance"][()]
+                benchmark_is_nuisance = [False if is_nuisance == 0 else True for is_nuisance in benchmark_is_nuisance]
+            except KeyError:
+                logging.info("HDF5 file does not contain is_nuisance field. Assuming is_nuisance=False for all benchmarks.")
+                benchmark_is_nuisance = [False for _ in benchmark_names]
+
+            phys_benchmark_names = []
+            for name, is_nuisance in zip(benchmark_names, benchmark_is_nuisance):
+                if not is_nuisance:
+                    phys_benchmark_names.append(name)
+
+            return phys_benchmark_names
 
         return benchmark_names
 

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -286,7 +286,9 @@ def load_benchmarks_from_madminer_file(filename, include_nuisance_benchmarks=Fal
                 benchmark_is_nuisance = f["benchmarks/is_nuisance"][()]
                 benchmark_is_nuisance = [False if is_nuisance == 0 else True for is_nuisance in benchmark_is_nuisance]
             except KeyError:
-                logging.info("HDF5 file does not contain is_nuisance field. Assuming is_nuisance=False for all benchmarks.")
+                logging.info(
+                    "HDF5 file does not contain is_nuisance field. Assuming is_nuisance=False for all benchmarks."
+                )
                 benchmark_is_nuisance = [False for _ in benchmark_names]
 
             phys_benchmark_names = []
@@ -327,7 +329,9 @@ def save_preformatted_events_to_madminer_file(
         f.create_dataset("samples/observations", data=observations)
 
 
-def save_nuisance_benchmarks_to_madminer_file(filename, weight_names, reference_benchmark=None, sort=True, copy_from=None):
+def save_nuisance_benchmarks_to_madminer_file(
+    filename, weight_names, reference_benchmark=None, sort=True, copy_from=None
+):
     """ Saves the names of nuisance-defined benchmarks in an HDF5 file """
 
     # Copy file

--- a/madminer/utils/interfaces/madminer_hdf5.py
+++ b/madminer/utils/interfaces/madminer_hdf5.py
@@ -5,9 +5,9 @@ import shutil
 import h5py
 import numpy as np
 from collections import OrderedDict
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def save_madminer_settings(

--- a/madminer/utils/interfaces/mg.py
+++ b/madminer/utils/interfaces/mg.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import shutil
-from madminer.utils.various import call_command, make_file_executable, create_missing_folders, general_init
+import logging
 
-logger = general_init(debug=None)
+from madminer.utils.various import call_command, make_file_executable, create_missing_folders
+
+logger = logging.getLogger(__name__)
 
 def generate_mg_process(
     mg_directory,

--- a/madminer/utils/interfaces/mg.py
+++ b/madminer/utils/interfaces/mg.py
@@ -8,6 +8,7 @@ from madminer.utils.various import call_command, make_file_executable, create_mi
 
 logger = logging.getLogger(__name__)
 
+
 def generate_mg_process(
     mg_directory,
     temp_directory,

--- a/madminer/utils/interfaces/mg.py
+++ b/madminer/utils/interfaces/mg.py
@@ -2,10 +2,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import shutil
-import logging
+from madminer.utils.various import call_command, make_file_executable, create_missing_folders, general_init
 
-from madminer.utils.various import call_command, make_file_executable, create_missing_folders
-
+logger = general_init(debug=None)
 
 def generate_mg_process(
     mg_directory,
@@ -52,7 +51,7 @@ def generate_mg_process(
     """
 
     # Preparations
-    logging.info("Generating MadGraph process folder from %s at %s", proc_card_file, mg_process_directory)
+    logger.info("Generating MadGraph process folder from %s at %s", proc_card_file, mg_process_directory)
 
     create_missing_folders([temp_directory, mg_process_directory, os.path.dirname(log_file)])
 
@@ -151,7 +150,7 @@ def prepare_run_mg_pythia(
         create_missing_folders([os.path.dirname(mg_process_directory + "/" + proc_card_filename_from_mgprocdir)])
 
     # Prepare run...
-    logging.info("Preparing script to run MadGraph and Pythia in %s", mg_process_directory)
+    logger.info("Preparing script to run MadGraph and Pythia in %s", mg_process_directory)
 
     # Bash script can optionally provide MG path or process directory
     mg_directory_placeholder = "$mgdir"
@@ -342,7 +341,7 @@ def run_mg_pythia(
         create_missing_folders([os.path.dirname(proc_card_filename)])
 
     # Just run it already
-    logging.info("Starting MadGraph and Pythia in %s", mg_process_directory)
+    logger.info("Starting MadGraph and Pythia in %s", mg_process_directory)
 
     # Copy cards
     if run_card_file is not None:

--- a/madminer/utils/interfaces/mg_cards.py
+++ b/madminer/utils/interfaces/mg_cards.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import six
-from madminer.utils.various import copy_file, general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def export_param_card(benchmark, parameters, param_card_template_file, mg_process_directory, param_card_filename=None):

--- a/madminer/utils/interfaces/mg_cards.py
+++ b/madminer/utils/interfaces/mg_cards.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-import six
 
-from madminer.utils.various import copy_file
+import six
+from madminer.utils.various import copy_file, general_init
+
+logger = general_init(debug=None)
 
 
 def export_param_card(benchmark, parameters, param_card_template_file, mg_process_directory, param_card_filename=None):

--- a/madminer/utils/interfaces/mg_cards.py
+++ b/madminer/utils/interfaces/mg_cards.py
@@ -147,3 +147,24 @@ def export_run_card(template_filename, run_card_filename, run_systematics=False,
     new_run_card = "\n".join(run_card_lines)
     with open(run_card_filename, "w") as file:
         file.write(new_run_card)
+
+
+def create_systematics_arguments(systematics):
+    # Put together systematics string for MadGraph
+    systematics_arguments = []
+
+    if self.run_scale_variation:
+        scale_variation_string = ",".join([str(factor) for factor in scale_variation])
+        if scales == "together" or scales == "independent" or scales == "mur":
+            systematics_arguments.append("'--mur={}'".format(scale_variation_string))
+        if scales == "together" or scales == "independent" or scales == "muf":
+            systematics_arguments.append("'--muf={}'".format(scale_variation_string))
+        if scales == "together":
+            systematics_arguments.append("'--together=mur,muf'")
+
+    if self.run_pdf_variation:
+        systematics_arguments.append("'--pdf={}'".format(pdf_variation.strip()))
+
+    self.systematics_arguments = ""
+    if len(systematics_arguments) > 0:
+        self.systematics_arguments = "[" + ", ".join(systematics_arguments) + "]"

--- a/madminer/utils/interfaces/mg_cards.py
+++ b/madminer/utils/interfaces/mg_cards.py
@@ -123,7 +123,7 @@ def export_run_card(template_filename, run_card_filename, systematics=None):
     # Remove old entries
     for i, line in enumerate(run_card_lines):
         comment_pos = line.find("#")
-        if i >= 0:
+        if comment_pos >= 0:
             line = line[:comment_pos]
 
         try:

--- a/madminer/utils/ml/flow_losses.py
+++ b/madminer/utils/ml/flow_losses.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import torch
 from torch.nn.modules.loss import MSELoss
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 def negative_log_likelihood(log_p_pred, t_pred, t_true):

--- a/madminer/utils/ml/flow_losses.py
+++ b/madminer/utils/ml/flow_losses.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import torch
 from torch.nn.modules.loss import MSELoss
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def negative_log_likelihood(log_p_pred, t_pred, t_true):

--- a/madminer/utils/ml/flow_trainer.py
+++ b/madminer/utils/ml/flow_trainer.py
@@ -10,9 +10,9 @@ from torch.utils.data.sampler import SubsetRandomSampler
 from torch.nn.utils import clip_grad_norm_
 
 from madminer.utils.ml.utils import check_for_nans_in_parameters
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class SmallGoldDataset(torch.utils.data.Dataset):

--- a/madminer/utils/ml/flow_trainer.py
+++ b/madminer/utils/ml/flow_trainer.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import numpy as np
 
 import torch
@@ -11,6 +10,9 @@ from torch.utils.data.sampler import SubsetRandomSampler
 from torch.nn.utils import clip_grad_norm_
 
 from madminer.utils.ml.utils import check_for_nans_in_parameters
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class SmallGoldDataset(torch.utils.data.Dataset):
@@ -201,7 +203,7 @@ def train_flow_model(
 
             # Check for NaNs
             if check_for_nans_in_parameters(model):
-                logging.warning("NaNs in parameters or gradients, stopping training!")
+                logger.warning("NaNs in parameters or gradients, stopping training!")
                 break
 
             # Optimizer step
@@ -216,7 +218,7 @@ def train_flow_model(
         # Validation
         if validation_split is None:
             if n_epochs_verbose is not None and n_epochs_verbose > 0 and (epoch + 1) % n_epochs_verbose == 0:
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.2f (%s)"
                     % (epoch + 1, total_losses_train[-1], individual_losses_train[-1])
                 )
@@ -268,7 +270,7 @@ def train_flow_model(
         # Print out information
         if n_epochs_verbose is not None and n_epochs_verbose > 0 and (epoch + 1) % n_epochs_verbose == 0:
             if early_stopping and epoch == early_stopping_epoch:
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.2f (%s), validation loss %.2f (%s) (*)"
                     % (
                         epoch + 1,
@@ -279,7 +281,7 @@ def train_flow_model(
                     )
                 )
             else:
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.2f (%s), validation loss %.2f (%s)"
                     % (
                         epoch + 1,
@@ -293,13 +295,13 @@ def train_flow_model(
         # Early stopping: actually stop training
         if early_stopping and early_stopping_patience is not None:
             if epoch - early_stopping_epoch >= early_stopping_patience > 0:
-                logging.info("No improvement for %s epochs, stopping training", epoch - early_stopping_epoch)
+                logger.info("No improvement for %s epochs, stopping training", epoch - early_stopping_epoch)
                 break
 
     # Early stopping: back to best state
     if early_stopping:
         if early_stopping_best_val_loss < total_val_loss:
-            logging.info(
+            logger.info(
                 "Early stopping after epoch %s, with loss %.2f compared to final loss %.2f",
                 early_stopping_epoch + 1,
                 early_stopping_best_val_loss,
@@ -307,7 +309,7 @@ def train_flow_model(
             )
             model.load_state_dict(early_stopping_best_model)
         else:
-            logging.info("Early stopping did not improve performance")
+            logger.info("Early stopping did not improve performance")
 
     # Save learning curve
     if learning_curve_folder is not None and learning_curve_filename is not None:
@@ -331,7 +333,7 @@ def train_flow_model(
                         individual_losses_val[:, i],
                     )
 
-    logging.info("Finished training")
+    logger.info("Finished training")
 
     return total_losses_train, total_losses_val
 

--- a/madminer/utils/ml/models/batch_norm.py
+++ b/madminer/utils/ml/models/batch_norm.py
@@ -9,6 +9,8 @@ from torch import tensor
 from madminer.utils.ml.models.base import BaseFlow
 
 
+
+
 class BatchNorm(BaseFlow):
     """BatchNorm implementation"""
 
@@ -71,7 +73,7 @@ class BatchNorm(BaseFlow):
         return x
 
     def to(self, *args, **kwargs):
-        logging.debug('Transforming BatchNorm to %s', args)
+        logger.debug('Transforming BatchNorm to %s', args)
 
         self = super().to(*args, **kwargs)
 

--- a/madminer/utils/ml/models/batch_norm.py
+++ b/madminer/utils/ml/models/batch_norm.py
@@ -2,13 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 import logging
 import numpy.random as rng
-
 import torch
 from torch import tensor
 
 from madminer.utils.ml.models.base import BaseFlow
 
-
+logger = logging.getLogger(__name__)
 
 
 class BatchNorm(BaseFlow):

--- a/madminer/utils/ml/models/made.py
+++ b/madminer/utils/ml/models/made.py
@@ -10,9 +10,9 @@ import torch.nn.functional as F
 from madminer.utils.ml.models.base import BaseFlow, BaseConditionalFlow
 from madminer.utils.ml.models.masks import create_degrees, create_masks, create_weights, create_weights_conditional
 from madminer.utils.ml.utils import get_activation_function
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class GaussianMADE(BaseFlow):

--- a/madminer/utils/ml/models/made.py
+++ b/madminer/utils/ml/models/made.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.random as rng
-import logging
-
 import torch
 from torch import tensor
 import torch.nn as nn
@@ -12,6 +10,9 @@ import torch.nn.functional as F
 from madminer.utils.ml.models.base import BaseFlow, BaseConditionalFlow
 from madminer.utils.ml.models.masks import create_degrees, create_masks, create_weights, create_weights_conditional
 from madminer.utils.ml.utils import get_activation_function
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class GaussianMADE(BaseFlow):
@@ -63,13 +64,13 @@ class GaussianMADE(BaseFlow):
             try:
                 h = self.activation_function(F.linear(h, torch.t(M * W), b))
             except (RuntimeError, AttributeError):
-                logging.error('Abort! Abort!')
-                logging.info('MADE settings: n_inputs = %s', self.n_inputs)
-                logging.info('Shapes: x %s, h %s, M %s, W %s, b %s',
+                logger.error('Abort! Abort!')
+                logger.info('MADE settings: n_inputs = %s', self.n_inputs)
+                logger.info('Shapes: x %s, h %s, M %s, W %s, b %s',
                              x.shape, h.shape, M.shape, W.shape, b.shape)
-                logging.info('Types: x %s, h %s, M %s, W %s, b %s',
+                logger.info('Types: x %s, h %s, M %s, W %s, b %s',
                              type(x), type(h), type(M), type(W), type(b))
-                logging.info('CUDA: x %s, h %s, M %s, W %s, b %s',
+                logger.info('CUDA: x %s, h %s, M %s, W %s, b %s',
                              x.is_cuda, h.is_cuda, M.is_cuda, W.is_cuda, b.is_cuda)
                 raise
 
@@ -209,13 +210,13 @@ class ConditionalGaussianMADE(BaseConditionalFlow):
             h = self.activation_function(
                 F.linear(theta, torch.t(self.Wx)) + F.linear(x, torch.t(self.Ms[0] * self.Ws[0]), self.bs[0]))
         except RuntimeError:
-            logging.error('Abort! Abort!')
-            logging.info('MADE settings: n_inputs = %s, n_conditionals = %s', self.n_inputs, self.n_conditionals)
-            logging.info('Shapes: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
+            logger.error('Abort! Abort!')
+            logger.info('MADE settings: n_inputs = %s, n_conditionals = %s', self.n_inputs, self.n_conditionals)
+            logger.info('Shapes: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
                          theta.shape, self.Wx.shape, x.shape, self.Ms[0].shape, self.Ws[0].shape, self.bs[0].shape)
-            logging.info('Types: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
+            logger.info('Types: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
                          type(theta), type(self.Wx), type(x), type(self.Ms[0]), type(self.Ws[0]), type(self.bs[0]))
-            logging.info('CUDA: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
+            logger.info('CUDA: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
                          theta.is_cuda, self.Wx.is_cuda, x.is_cuda, self.Ms[0].is_cuda, self.Ws[0].is_cuda,
                          self.bs[0].is_cuda)
             raise

--- a/madminer/utils/ml/models/made_mog.py
+++ b/madminer/utils/ml/models/made_mog.py
@@ -8,9 +8,9 @@ import torch.nn.functional as F
 from madminer.utils.ml.models.base import BaseConditionalFlow
 from madminer.utils.ml.models.masks import create_degrees, create_masks, create_weights_conditional
 from madminer.utils.ml.utils import get_activation_function
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class ConditionalMixtureMADE(BaseConditionalFlow):

--- a/madminer/utils/ml/models/made_mog.py
+++ b/madminer/utils/ml/models/made_mog.py
@@ -2,15 +2,15 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.random as rng
-import logging
-
 import torch
 from torch import tensor
 import torch.nn.functional as F
-
 from madminer.utils.ml.models.base import BaseConditionalFlow
 from madminer.utils.ml.models.masks import create_degrees, create_masks, create_weights_conditional
 from madminer.utils.ml.utils import get_activation_function
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class ConditionalMixtureMADE(BaseConditionalFlow):
@@ -31,7 +31,7 @@ class ConditionalMixtureMADE(BaseConditionalFlow):
         # create network's parameters
         self.degrees = create_degrees(n_inputs, n_hiddens, input_order, mode)
         self.Ms, self.Mmp = create_masks(self.degrees)
-        logging.debug('Mmp shape: %s', self.Mmp.shape)
+        logger.debug('Mmp shape: %s', self.Mmp.shape)
         (self.Wx, self.Ws, self.bs, self.Wm, self.bm, self.Wp, self.bp, self.Wa,
          self.ba) = create_weights_conditional(
             n_conditionals,
@@ -79,15 +79,15 @@ class ConditionalMixtureMADE(BaseConditionalFlow):
             h = self.activation_function(
                 F.linear(theta, torch.t(self.Wx)) + F.linear(x, torch.t(self.Ms[0] * self.Ws[0]), self.bs[0]))
         except RuntimeError:
-            logging.error('Abort! Abort!')
-            logging.info('MADE settings: n_inputs = %s, n_conditionals = %s', self.n_inputs, self.n_conditionals)
-            logging.info('Shapes: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
+            logger.error('Abort! Abort!')
+            logger.info('MADE settings: n_inputs = %s, n_conditionals = %s', self.n_inputs, self.n_conditionals)
+            logger.info('Shapes: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
                          theta.shape, self.Wx.shape, x.shape, self.Ms[0].shape, self.Ws[0].shape, self.bs[0].shape)
-            logging.info('dtypes: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
+            logger.info('dtypes: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
                          theta.dtype, self.Wx.dtype, x.dtype, self.Ms[0].dtype, self.Ws[0].dtype, self.bs[0].dtype)
-            logging.info('Types: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
+            logger.info('Types: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
                          type(theta), type(self.Wx), type(x), type(self.Ms[0]), type(self.Ws[0]), type(self.bs[0]))
-            logging.info('CUDA: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
+            logger.info('CUDA: theta %s, Wx %s, x %s, Ms %s, Ws %s, bs %s',
                          theta.is_cuda, self.Wx.is_cuda, x.is_cuda, self.Ms[0].is_cuda, self.Ws[0].is_cuda,
                          self.bs[0].is_cuda)
             raise

--- a/madminer/utils/ml/models/maf.py
+++ b/madminer/utils/ml/models/maf.py
@@ -6,9 +6,9 @@ from torch import tensor
 from madminer.utils.ml.models.base import BaseFlow, BaseConditionalFlow
 from madminer.utils.ml.models.made import GaussianMADE, ConditionalGaussianMADE
 from madminer.utils.ml.models.batch_norm import BatchNorm
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class MaskedAutoregressiveFlow(BaseFlow):

--- a/madminer/utils/ml/models/maf.py
+++ b/madminer/utils/ml/models/maf.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy.random as rng
-import logging
-
 import torch.nn as nn
 from torch import tensor
-
 from madminer.utils.ml.models.base import BaseFlow, BaseConditionalFlow
 from madminer.utils.ml.models.made import GaussianMADE, ConditionalGaussianMADE
 from madminer.utils.ml.models.batch_norm import BatchNorm
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class MaskedAutoregressiveFlow(BaseFlow):
@@ -160,10 +160,10 @@ class ConditionalMaskedAutoregressiveFlow(BaseConditionalFlow):
 
         """
         if x.shape[1] != self.n_inputs:
-            logging.error('x has wrong shape: %s', x.shape)
-            logging.debug('theta shape: %s', theta.shape)
-            logging.debug('theta content: %s', theta)
-            logging.debug('x content: %s', x)
+            logger.error('x has wrong shape: %s', x.shape)
+            logger.debug('theta shape: %s', theta.shape)
+            logger.debug('theta content: %s', theta)
+            logger.debug('x content: %s', x)
 
             raise ValueError('Wrong x shape')
 

--- a/madminer/utils/ml/models/maf_mog.py
+++ b/madminer/utils/ml/models/maf_mog.py
@@ -5,9 +5,9 @@ from madminer.utils.ml.models.base import BaseConditionalFlow
 from madminer.utils.ml.models.made import ConditionalGaussianMADE
 from madminer.utils.ml.models.batch_norm import BatchNorm
 from madminer.utils.ml.models.made_mog import ConditionalMixtureMADE
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class ConditionalMixtureMaskedAutoregressiveFlow(BaseConditionalFlow):

--- a/madminer/utils/ml/models/maf_mog.py
+++ b/madminer/utils/ml/models/maf_mog.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-import logging
-
 import torch.nn as nn
-
 from madminer.utils.ml.models.base import BaseConditionalFlow
 from madminer.utils.ml.models.made import ConditionalGaussianMADE
 from madminer.utils.ml.models.batch_norm import BatchNorm
 from madminer.utils.ml.models.made_mog import ConditionalMixtureMADE
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class ConditionalMixtureMaskedAutoregressiveFlow(BaseConditionalFlow):
@@ -55,10 +55,10 @@ class ConditionalMixtureMaskedAutoregressiveFlow(BaseConditionalFlow):
 
     def forward(self, theta, x, fix_batch_norm=None):
         if x.shape[1] != self.n_inputs:
-            logging.error('x has wrong shape: %s', x.shape)
-            logging.debug('theta shape: %s', theta.shape)
-            logging.debug('theta content: %s', theta)
-            logging.debug('x content: %s', x)
+            logger.error('x has wrong shape: %s', x.shape)
+            logger.debug('theta shape: %s', theta.shape)
+            logger.debug('theta content: %s', theta)
+            logger.debug('x content: %s', x)
 
             raise ValueError('Wrong x shape')
 

--- a/madminer/utils/ml/models/masks.py
+++ b/madminer/utils/ml/models/masks.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import numpy.random as rng
-
 from torch import tensor
 import torch.nn as nn
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 def create_degrees(n_inputs, n_hiddens, input_order, mode):

--- a/madminer/utils/ml/models/masks.py
+++ b/madminer/utils/ml/models/masks.py
@@ -4,9 +4,9 @@ import numpy as np
 import numpy.random as rng
 from torch import tensor
 import torch.nn as nn
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def create_degrees(n_inputs, n_hiddens, input_order, mode):

--- a/madminer/utils/ml/models/ratio.py
+++ b/madminer/utils/ml/models/ratio.py
@@ -4,9 +4,9 @@ import torch
 import torch.nn as nn
 from torch.autograd import grad
 from madminer.utils.ml.utils import get_activation_function
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class ParameterizedRatioEstimator(nn.Module):

--- a/madminer/utils/ml/models/ratio.py
+++ b/madminer/utils/ml/models/ratio.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 import torch.nn as nn
 from torch.autograd import grad
-
 from madminer.utils.ml.utils import get_activation_function
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class ParameterizedRatioEstimator(nn.Module):

--- a/madminer/utils/ml/models/score.py
+++ b/madminer/utils/ml/models/score.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 import torch.nn as nn
 from torch.autograd import grad
-
 from madminer.utils.ml.utils import get_activation_function
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class LocalScoreEstimator(nn.Module):

--- a/madminer/utils/ml/models/score.py
+++ b/madminer/utils/ml/models/score.py
@@ -4,9 +4,9 @@ import torch
 import torch.nn as nn
 from torch.autograd import grad
 from madminer.utils.ml.utils import get_activation_function
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class LocalScoreEstimator(nn.Module):

--- a/madminer/utils/ml/ratio_losses.py
+++ b/madminer/utils/ml/ratio_losses.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
-
 import torch
 from torch.nn import BCELoss, MSELoss
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 def ratio_mse_num(s_hat, log_r_hat, t0_hat, t1_hat, y_true, r_true, t0_true, t1_true, log_r_clip=10.0):

--- a/madminer/utils/ml/ratio_losses.py
+++ b/madminer/utils/ml/ratio_losses.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import torch
 from torch.nn import BCELoss, MSELoss
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def ratio_mse_num(s_hat, log_r_hat, t0_hat, t1_hat, y_true, r_true, t0_true, t1_true, log_r_clip=10.0):

--- a/madminer/utils/ml/ratio_trainer.py
+++ b/madminer/utils/ml/ratio_trainer.py
@@ -9,9 +9,9 @@ from torch.utils.data.sampler import SubsetRandomSampler
 from torch.nn.utils import clip_grad_norm_
 
 from madminer.utils.ml.models.ratio import ParameterizedRatioEstimator, DoublyParameterizedRatioEstimator
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 class GoldDataset(torch.utils.data.Dataset):
     """ """

--- a/madminer/utils/ml/ratio_trainer.py
+++ b/madminer/utils/ml/ratio_trainer.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import numpy as np
-
 import torch
 from torch import tensor
 import torch.optim as optim
@@ -11,7 +9,9 @@ from torch.utils.data.sampler import SubsetRandomSampler
 from torch.nn.utils import clip_grad_norm_
 
 from madminer.utils.ml.models.ratio import ParameterizedRatioEstimator, DoublyParameterizedRatioEstimator
+from madminer.utils.various import general_init
 
+logger = general_init(debug=None)
 
 class GoldDataset(torch.utils.data.Dataset):
     """ """
@@ -270,7 +270,7 @@ def train_ratio_model(
         # Validation
         if validation_split is None:
             if n_epochs_verbose is not None and n_epochs_verbose > 0 and (epoch + 1) % n_epochs_verbose == 0:
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.2f (%s)"
                     % (epoch + 1, total_losses_train[-1], individual_losses_train[-1])
                 )
@@ -339,7 +339,7 @@ def train_ratio_model(
         # Print out information
         if n_epochs_verbose is not None and n_epochs_verbose > 0 and (epoch + 1) % n_epochs_verbose == 0:
             if early_stopping and epoch == early_stopping_epoch:
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.2f (%s), validation loss %.2f (%s) (*)"
                     % (
                         epoch + 1,
@@ -350,7 +350,7 @@ def train_ratio_model(
                     )
                 )
             else:
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.2f (%s), validation loss %.2f (%s)"
                     % (
                         epoch + 1,
@@ -364,13 +364,13 @@ def train_ratio_model(
         # Early stopping: actually stop training
         if early_stopping and early_stopping_patience is not None:
             if epoch - early_stopping_epoch >= early_stopping_patience > 0:
-                logging.info("No improvement for %s epochs, stopping training", epoch - early_stopping_epoch)
+                logger.info("No improvement for %s epochs, stopping training", epoch - early_stopping_epoch)
                 break
 
     # Early stopping: back to best state
     if early_stopping:
         if early_stopping_best_val_loss < total_val_loss:
-            logging.info(
+            logger.info(
                 "Early stopping after epoch %s, with loss %.2f compared to final loss %.2f",
                 early_stopping_epoch + 1,
                 early_stopping_best_val_loss,
@@ -378,7 +378,7 @@ def train_ratio_model(
             )
             model.load_state_dict(early_stopping_best_model)
         else:
-            logging.info("Early stopping did not improve performance")
+            logger.info("Early stopping did not improve performance")
 
     # Save learning curve
     if learning_curve_folder is not None and learning_curve_filename is not None:
@@ -402,7 +402,7 @@ def train_ratio_model(
                         individual_losses_val[:, i],
                     )
 
-    logging.info("Finished training")
+    logger.info("Finished training")
 
     return total_losses_train, total_losses_val
 

--- a/madminer/utils/ml/ratio_trainer.py
+++ b/madminer/utils/ml/ratio_trainer.py
@@ -13,6 +13,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class GoldDataset(torch.utils.data.Dataset):
     """ """
 

--- a/madminer/utils/ml/score_trainer.py
+++ b/madminer/utils/ml/score_trainer.py
@@ -7,9 +7,9 @@ import torch.optim as optim
 from torch.utils.data import Dataset, DataLoader
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.nn.utils import clip_grad_norm_
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class LocalScoreDataset(torch.utils.data.Dataset):

--- a/madminer/utils/ml/score_trainer.py
+++ b/madminer/utils/ml/score_trainer.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import logging
 import numpy as np
-
 import torch
 from torch import tensor
 import torch.optim as optim
 from torch.utils.data import Dataset, DataLoader
 from torch.utils.data.sampler import SubsetRandomSampler
 from torch.nn.utils import clip_grad_norm_
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class LocalScoreDataset(torch.utils.data.Dataset):
@@ -200,7 +201,7 @@ def train_local_score_model(
                         individual_loss_string += ", "
                     individual_loss_string += "{}: {:.4f}".format(label, value)
 
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.4f (%s)" % (epoch + 1, total_losses_train[-1], individual_loss_string)
                 )
             continue
@@ -253,26 +254,26 @@ def train_local_score_model(
                 individual_loss_string_val += "{}: {:.4f}".format(label, value_val)
 
             if early_stopping and epoch == early_stopping_epoch:
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.4f (%s)", epoch + 1, total_losses_train[-1], individual_loss_string_train
                 )
-                logging.info("            val. loss  %.4f (%s) (*)", total_losses_val[-1], individual_loss_string_val)
+                logger.info("            val. loss  %.4f (%s) (*)", total_losses_val[-1], individual_loss_string_val)
             else:
-                logging.info(
+                logger.info(
                     "  Epoch %d: train loss %.4f (%s)", epoch + 1, total_losses_train[-1], individual_loss_string_train
                 )
-                logging.info("            val. loss  %.4f (%s)", total_losses_val[-1], individual_loss_string_val)
+                logger.info("            val. loss  %.4f (%s)", total_losses_val[-1], individual_loss_string_val)
 
         # Early stopping: actually stop training
         if early_stopping and early_stopping_patience is not None:
             if epoch - early_stopping_epoch >= early_stopping_patience > 0:
-                logging.info("No improvement for %s epochs, stopping training", epoch - early_stopping_epoch)
+                logger.info("No improvement for %s epochs, stopping training", epoch - early_stopping_epoch)
                 break
 
     # Early stopping: back to best state
     if early_stopping:
         if early_stopping_best_val_loss < total_val_loss:
-            logging.info(
+            logger.info(
                 "Early stopping after epoch %s, with loss %.2f compared to final loss %.2f",
                 early_stopping_epoch + 1,
                 early_stopping_best_val_loss,
@@ -280,7 +281,7 @@ def train_local_score_model(
             )
             model.load_state_dict(early_stopping_best_model)
         else:
-            logging.info("Early stopping did not improve performance")
+            logger.info("Early stopping did not improve performance")
 
     # Save learning curve
     if learning_curve_folder is not None and learning_curve_filename is not None:
@@ -304,7 +305,7 @@ def train_local_score_model(
                         individual_losses_val[:, i],
                     )
 
-    logging.info("Finished training")
+    logger.info("Finished training")
 
     return total_losses_train, total_losses_val
 

--- a/madminer/utils/ml/utils.py
+++ b/madminer/utils/ml/utils.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 import torch
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 def get_activation_function(activation):

--- a/madminer/utils/ml/utils.py
+++ b/madminer/utils/ml/utils.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 import torch
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 def get_activation_function(activation):

--- a/madminer/utils/particle.py
+++ b/madminer/utils/particle.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from skhep.math.vectors import LorentzVector
+from madminer.utils.various import general_init
+
+logger = general_init(debug=None)
 
 
 class MadMinerParticle(LorentzVector):

--- a/madminer/utils/particle.py
+++ b/madminer/utils/particle.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from skhep.math.vectors import LorentzVector
-from madminer.utils.various import general_init
+import logging
 
-logger = general_init(debug=None)
+logger = logging.getLogger(__name__)
 
 
 class MadMinerParticle(LorentzVector):

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -17,7 +17,7 @@ printed_splash = False
 def general_init(debug=False):
     global printed_splash
 
-    logging.basicConfig(format="%(asctime)s  %(message)s", datefmt="%H:%M")
+    logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", datefmt="%H:%M")
     logging.getLogger().setLevel(logging.DEBUG if debug else logging.INFO)
 
     if not printed_splash:

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -17,7 +17,7 @@ printed_splash = False
 def general_init(debug=False):
     global printed_splash
 
-    logging.basicConfig(format="%(asctime)s %(levelname)s: %(message)s", datefmt="%H:%M")
+    logging.basicConfig(format="%(asctime)s %(levelname)s:    %(message)s", datefmt="%H:%M")
     logging.getLogger().setLevel(logging.DEBUG if debug else logging.INFO)
 
     if not printed_splash:

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -8,40 +8,10 @@ from subprocess import Popen, PIPE
 import io
 import numpy as np
 import shutil
-from madminer import __version__
 
-printed_splash = False
+logger = logging.getLogger(__name__)
 
-
-def general_init(debug=False):
-    global printed_splash
-
-    logger = logging.getLogger("madminer")
-    formatter = logging.Formatter(fmt="%(asctime)s %(message)s", datefmt="%H:%M")
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-    if debug is not None:
-        logger.setLevel(level=logging.DEBUG if debug else logging.INFO)
-
-    if not printed_splash:
-        logger.info("")
-        logger.info("------------------------------------------------------------")
-        logger.info("|                                                          |")
-        logger.info("|  MadMiner v{}|".format(__version__.ljust(46)))
-        logger.info("|                                                          |")
-        logger.info("|           Johann Brehmer, Kyle Cranmer, and Felix Kling  |")
-        logger.info("|                                                          |")
-        logger.info("------------------------------------------------------------")
-        logger.info("")
-
-        printed_splash = True
-
-    return logger
-
-
-logger = general_init(debug=None)
+initialized = False
 
 
 def call_command(cmd, log_file=None):
@@ -202,42 +172,18 @@ def math_commands():
     ]
 
     mathdefinitions = {}
-    for function in functions:
-        mathdefinitions[function] = locals().get(function, None)
+    for f in functions:
+        mathdefinitions[f] = locals().get(f, None)
 
     return mathdefinitions
 
 
 def make_file_executable(filename):
-    """
-
-    Parameters
-    ----------
-    filename :
-        
-
-    Returns
-    -------
-
-    """
     st = os.stat(filename)
     os.chmod(filename, st.st_mode | stat.S_IEXEC)
 
 
 def copy_file(source, destination):
-    """
-
-    Parameters
-    ----------
-    source :
-        
-    destination :
-        
-
-    Returns
-    -------
-
-    """
     if source is None:
         return
 

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -244,3 +244,7 @@ def weighted_quantile(values, quantiles, sample_weight=None, values_sorted=False
         weighted_quantiles /= np.sum(sample_weight)
 
     return np.interp(quantiles, weighted_quantiles, values)
+
+
+def approx_equal(a, b, epsilon=1.0e-6):
+    return abs(a - b) < epsilon

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -18,7 +18,8 @@ def general_init(debug=False):
     global printed_splash
 
     logging.basicConfig(format="%(asctime)s %(levelname)s:    %(message)s", datefmt="%H:%M")
-    logging.getLogger().setLevel(logging.DEBUG if debug else logging.INFO)
+    logger = logging.getLogger("madminer")
+    logger.setLevel(logging.DEBUG if debug else logging.INFO)
 
     if not printed_splash:
         logging.info("")
@@ -32,6 +33,8 @@ def general_init(debug=False):
         logging.info("")
 
         printed_splash = True
+
+    return logger
 
 
 def call_command(cmd, log_file=None):

--- a/madminer/utils/various.py
+++ b/madminer/utils/various.py
@@ -111,10 +111,14 @@ def balance_thetas(theta_sets_types, theta_sets_values):
     return theta_sets_types, theta_sets_values
 
 
-def sanitize_array(array, replace_nan=0.0, replace_inf=0.0, replace_neg_inf=0.0):
+def sanitize_array(array, replace_nan=0.0, replace_inf=0.0, replace_neg_inf=0.0, min_value=None, max_value=None):
     array[np.isneginf(array)] = replace_neg_inf
     array[np.isinf(array)] = replace_inf
     array[np.isnan(array)] = replace_nan
+
+    if min_value is not None or max_value is not None:
+        array = np.clip(array, min_value, max_value)
+
     return array
 
 


### PR DESCRIPTION
This PR contains some major and breaking changes, which will be the backbone for v0.2.0. Most changes are tested to some degree, but certainly not enough. I'm sure that this breaks all of the tutorials.

### New features:
- Estimate **systematic uncertainties** by reweighting to other PDF members or scale choices. The first step is calling `MadMiner.set_systematics()` before `MadMiner.run()`.
- For each varied scale and each alternative PDF set / member, we introduce one nuisance parameter. The event weights as a function of these nuisance parameters are modeled as an exponential, the coefficients are determined from the event weights by the new `NuisanceMorpher` class. As a constraint term we assume a Gaussian.
- `SampleAugmenter.extract_samples_train_local()` can now calculate the **score with respect to both the physical parameters and the nuisance parameters**. This means the user can train a SALLY estimator that predicts the score with respect to both types of parameters. With the profiling functions in `madminer.fisherinformation`, the Fisher information profiled over the nuisance parameters can be calculated. Note that so far the other `SampleAugmenter` functions do not support nuisance parameters.
- **Additional (non-morphing) benchmarks** can be defined in `MadMiner` without breaking or resetting the morphing.
- No need for the Pythia / Delphes patch anymore: `DelphesProcessor` can **extract the event weights from the LHE file** instead of the Pythia / Delphes file. This is not a great long term solution, though, since we can't explicitly check that the events match between the files.
- `DelphesProcessor` allows **k factors**.
- **No unnecessary running of Delphes** in `DelphesProcessor`.
- New function **`plot_distributions()`** in `madminer.plotting` to, well, plot distributions. It can plot the systematic uncertainties as error bands.

### Breaking / API changes:
- `DelphesProcessor.add_sample()` replaces `DelphesProcessor.add_hepmc_sample()`.
- `MadMiner.set_morphing()` replaces `MadMiner.set_benchmarks_from_morphing()`.

### Bug fixes:
- Fixed critical bug in the evaluation of the score with ensemble methods. This led to wrong results for the detector-level Fisher information.
- Fixed wrong calculation of the covariance of truth-type Fisher information matrices.

### Internal changes:
- MadMiner file now includes systematics / nuisance parameter data.
- Renamed some submodules in `madminer.utils.interfaces`.
- Removed unnecessary static functions in `MadMiner`.
- Restructured logging, now the user is responsible for setting up handlers.
- Rewrote profiling algorithm.
