### PR TITLE
Fixed link to mining gold paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ approach discards the information in all other observables and often does not sc
 In the three publications
 ["Constraining Effective Field Theories With Machine Learning"](https://arxiv.org/abs/1805.00013),
 ["A Guide to Constraining Effective Field Theories With Machine Learning"](https://arxiv.org/abs/1805.00020), and
-["Mining gold from implicit models to improve likelihood-free inference"](https://arxiv.org/abs/1805.00020),
+["Mining gold from implicit models to improve likelihood-free inference"](https://arxiv.org/abs/1805.12244),
 a new approach has been developed. In a nut shell, additional information is extracted from the simulators. This
 "augmented data" can be used to train neural networks to efficiently approximate arbitrary likelihood ratios. We
 playfully call this process "mining gold" from the simulator, since this information may be hard to get, but turns out


### PR DESCRIPTION
The README link to the mining gold paper was pointing to the constraining EFT with ML guide, fixed now.