### PR TITLE
Copying back tensors to CPU for model evaluation when running on GPUs to prevent crash, minor tutorial update

### DIFF
--- a/examples/toy_example/toy_example.ipynb
+++ b/examples/toy_example/toy_example.ipynb
@@ -40,7 +40,6 @@
     "import matplotlib\n",
     "from matplotlib import pyplot as plt\n",
     "%matplotlib inline\n",
-    "import corner\n",
     "\n",
     "from madminer.ml import MLForge"
    ]

--- a/madminer/utils/ml/ratio_trainer.py
+++ b/madminer/utils/ml/ratio_trainer.py
@@ -571,13 +571,14 @@ def evaluate_ratio_model(
             else:
                 raise ValueError("Unknown method type %s", method_type)
 
-            # Get data and return
+            # Copy back tensors to CPU
             if run_on_gpu:
-              s_hat = s_hat.cpu().detach().numpy().flatten()
-              log_r_hat = log_r_hat.cpu().detach().numpy().flatten()
-            else:
-              s_hat = s_hat.detach().numpy().flatten()
-              log_r_hat = log_r_hat.detach().numpy().flatten()
+                s_hat = s_hat.cpu()
+                log_r_hat = log_r_hat.cpu()
+
+            # Get data and return
+            s_hat = s_hat.detach().numpy().flatten()
+            log_r_hat = log_r_hat.detach().numpy().flatten()
             t_hat0, t_hat1 = None, None
 
     if return_grad_x:

--- a/madminer/utils/ml/ratio_trainer.py
+++ b/madminer/utils/ml/ratio_trainer.py
@@ -572,8 +572,12 @@ def evaluate_ratio_model(
                 raise ValueError("Unknown method type %s", method_type)
 
             # Get data and return
-            s_hat = s_hat.detach().numpy().flatten()
-            log_r_hat = log_r_hat.detach().numpy().flatten()
+            if run_on_gpu:
+              s_hat = s_hat.cpu().detach().numpy().flatten()
+              log_r_hat = log_r_hat.cpu().detach().numpy().flatten()
+            else:
+              s_hat = s_hat.detach().numpy().flatten()
+              log_r_hat = log_r_hat.detach().numpy().flatten()
             t_hat0, t_hat1 = None, None
 
     if return_grad_x:

--- a/madminer/utils/ml/score_trainer.py
+++ b/madminer/utils/ml/score_trainer.py
@@ -379,7 +379,7 @@ def evaluate_local_score_model(model, xs=None, run_on_gpu=True, double_precision
     t_hat = t_hat.detach().numpy()
 
     if return_grad_x:
-        x_gradients = x_gradients.cpu().detach().numpy()
+        x_gradients = x_gradients.detach().numpy()
         return t_hat, x_gradients
 
     return t_hat

--- a/madminer/utils/ml/score_trainer.py
+++ b/madminer/utils/ml/score_trainer.py
@@ -370,11 +370,16 @@ def evaluate_local_score_model(model, xs=None, run_on_gpu=True, double_precision
             t_hat = model(xs)
         x_gradients = None
 
+    # Copy back tensors to CPU
+    if run_on_gpu:
+      t_hat = t_hat.cpu()
+      x_gradients = x_gradients.cpu()
+
     # Get data and return
     t_hat = t_hat.detach().numpy()
 
     if return_grad_x:
-        x_gradients = x_gradients.detach().numpy()
+        x_gradients = x_gradients.cpu().detach().numpy()
         return t_hat, x_gradients
 
     return t_hat


### PR DESCRIPTION
When running on GPUs, the model evaluation step throws the following error for me: `TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.`. This is fixed with this MR. I am not sure whether this is related to the systems and environments I have used to test this and it works already without this fix on different setups.

Besides, the `corner` library is no longer needed for the toy example, so the import was removed.